### PR TITLE
Adjustment to break point level scaling

### DIFF
--- a/Source/msfa/dx7note.cc
+++ b/Source/msfa/dx7note.cc
@@ -114,9 +114,9 @@ int ScaleLevel(int midinote, int break_pt, int left_depth, int right_depth,
                int left_curve, int right_curve) {
     int offset = midinote - break_pt - 17;
     if (offset >= 0) {
-        return ScaleCurve(offset / 3, right_depth, right_curve);
+        return ScaleCurve((offset+1) / 3, right_depth, right_curve);
     } else {
-        return ScaleCurve((-offset) / 3, left_depth, left_curve);
+        return ScaleCurve(-(offset-1) / 3, left_depth, left_curve);
     }
 }
 


### PR DESCRIPTION
 Adjustment to break point level scaling to match Yamaha DX7.



![dexed breakpoint](https://cloud.githubusercontent.com/assets/18003792/20254317/222eeff4-aa01-11e6-9e48-aae37ee10406.png)
Comparison image shows C1 to C4,  break point C3, -Lin curve, Depth 99


