### PR TITLE
use native log2 and round in vs2013+

### DIFF
--- a/Source/EngineMkI.cpp
+++ b/Source/EngineMkI.cpp
@@ -35,13 +35,15 @@
 #endif
 
 #ifdef _WIN32
+#if _MSC_VER < 1800
     double log2(double n)  {  
         return log(n) / log(2.0);  
     }
     double round(double n) {
         return n < 0.0 ? ceil(n - 0.5) : floor(n + 0.5);
     }
-    __declspec(align(16)) int zeros[N] = {0};
+#endif
+    __declspec(align(16)) const int zeros[N] = {0};
 #else
     const int32_t __attribute__ ((aligned(16))) zeros[N] = {0};
 #endif

--- a/Source/EngineOpl.cpp
+++ b/Source/EngineOpl.cpp
@@ -26,7 +26,7 @@
 #include "EngineOpl.h"
 
 #ifdef _WIN32
-    __declspec(align(16)) int zeros[N] = {0};
+    __declspec(align(16)) const int zeros[N] = {0};
 #else
     const int32_t __attribute__ ((aligned(16))) zeros[N] = {0};
 #endif


### PR DESCRIPTION
vs2013+ support C99 **round** and **log2** functions, so let's get rid of warning