### PR TITLE
edited Fine tune modifier key,  and Popup menu modifier.

### DIFF
--- a/Source/CartManager.cpp
+++ b/Source/CartManager.cpp
@@ -213,7 +213,7 @@ void CartManager::fileDoubleClicked(const File& file) {
 }
 
 void CartManager::fileClicked(const File& file, const MouseEvent& e) {
-    if ( e.mods.isRightButtonDown() || e.mods.isAnyModifierKeyDown() ) {
+    if ( e.mods.isPopupMenu()) {
         PopupMenu menu;
         
         menu.addItem(1000, "Open location");

--- a/Source/GlobalEditor.cpp
+++ b/Source/GlobalEditor.cpp
@@ -641,7 +641,7 @@ void GlobalEditor::setMonoState(bool state)  {
 }
 
 void GlobalEditor::mouseDown(const MouseEvent &e) {
-    if ( e.mods.isRightButtonDown() || e.mods.isAnyModifierKeyDown() ) {
+    if ( e.mods.isPopupMenu()) {
         PopupMenu popup;
         popup.addItem(1, "Send current program to DX7");
         if ( popup.show() == 1 )

--- a/Source/OperatorEditor.cpp
+++ b/Source/OperatorEditor.cpp
@@ -518,7 +518,7 @@ void OperatorEditor::updateEnvPos(char pos) {
 }
 
 void OperatorEditor::mouseDown(const MouseEvent &event) {
-    if ( event.mods.isRightButtonDown()  || event.mods.isAnyModifierKeyDown()) {
+    if ( event.mods.isPopupMenu()) {
         PopupMenu popup;
 
         popup.addItem(1, "Copy Operator Values");

--- a/Source/PluginParam.cpp
+++ b/Source/PluginParam.cpp
@@ -215,7 +215,7 @@ void Ctrl::bind(Slider *s) {
     updateComponent();
     s->addListener(this);
     s->addMouseListener(this, true);
-    s->setVelocityModeParameters (0.1, 1, 0.05, 1);
+    s->setVelocityModeParameters (0.1, 1, 0.05, 1, ModifierKeys::shiftModifier);
 }
 
 void Ctrl::bind(Button *b) {
@@ -280,7 +280,7 @@ void Ctrl::mouseEnter(const juce::MouseEvent &event) {
 }
 
 void Ctrl::mouseDown(const juce::MouseEvent &event) {
-    if ( event.mods.isRightButtonDown() || event.mods.isAnyModifierKeyDown()) {
+    if ( event.mods.isPopupMenu()) {
         PopupMenu popup;
 
         if ( parent->mappedMidiCC.containsValue(this) ) {

--- a/Source/ProgramListBox.cpp
+++ b/Source/ProgramListBox.cpp
@@ -107,7 +107,7 @@ void ProgramListBox::mouseDown(const MouseEvent &event) {
     
     int pos = programPosition(event.getMouseDownX(), event.getMouseDownY());
 
-    if ( event.mods.isRightButtonDown() || event.mods.isAnyModifierKeyDown() ) {
+    if ( event.mods.isPopupMenu()) {
         listener->programRightClicked(this, pos);
         return;
     }


### PR DESCRIPTION
 Resolves a conflict with fine tune modifier also bringing up the Popup menu.  (Ctrl with left mouse button)

- Using Shift to fine tune sliders, (Ctrl click already reserved on Mac to emulate right click.)
- Using typical method to show Popup menus. On Windows/Linux right click. On Mac Ctrl click, or right click.

 #140 