### PR TITLE
Add option to keep keyboard focussed on the MIDI keyboard

### DIFF
--- a/Builds/VisualStudio2017/Dexed_SharedCode.vcxproj
+++ b/Builds/VisualStudio2017/Dexed_SharedCode.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -267,6 +267,7 @@
     <Lib />
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\Source\DexedMidiKeyboardComponent.cpp" />
     <ClCompile Include="..\..\Source\PluginFx.cpp" />
     <ClCompile Include="..\..\Source\EngineMkI.cpp" />
     <ClCompile Include="..\..\Source\EngineOpl.cpp" />
@@ -1945,6 +1946,7 @@
     <ClCompile Include="..\..\JuceLibraryCode\include_juce_gui_extra.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\Source\DexedMidiKeyboardComponent.h" />
     <ClInclude Include="..\..\Source\PluginFx.h" />
     <ClInclude Include="..\..\Source\EngineMkI.h" />
     <ClInclude Include="..\..\Source\EngineOpl.h" />

--- a/Builds/VisualStudio2017/Dexed_SharedCode.vcxproj
+++ b/Builds/VisualStudio2017/Dexed_SharedCode.vcxproj
@@ -21,7 +21,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{2C37C8E6-9441-931F-C487-ECA465F8F303}</ProjectGuid>
     <PlatformToolset>v141</PlatformToolset>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
     <UseIntelIPP>Parallel_Static</UseIntelIPP>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
@@ -31,7 +31,7 @@
     <WholeProgramOptimization>false</WholeProgramOptimization>
     <PlatformToolset>v141</PlatformToolset>
     <PlatformToolset>v141</PlatformToolset>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
     <UseIntelIPP>Parallel_Static</UseIntelIPP>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -40,7 +40,7 @@
     <WholeProgramOptimization>false</WholeProgramOptimization>
     <PlatformToolset>v141</PlatformToolset>
     <PlatformToolset>v141</PlatformToolset>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
     <UseIntelIPP>Parallel_Static</UseIntelIPP>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
@@ -49,7 +49,7 @@
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <PlatformToolset>v141</PlatformToolset>
     <PlatformToolset>v141</PlatformToolset>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
     <UseIntelIPP>Parallel_Static</UseIntelIPP>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
@@ -58,7 +58,7 @@
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <PlatformToolset>v141</PlatformToolset>
     <PlatformToolset>v141</PlatformToolset>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
     <UseIntelIPP>Parallel_Static</UseIntelIPP>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
@@ -68,7 +68,7 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros">
     <PlatformToolset>v141</PlatformToolset>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
     <UseIntelIPP>Parallel_Static</UseIntelIPP>
   </PropertyGroup>
   <PropertyGroup>
@@ -91,7 +91,7 @@
     <GenerateManifest Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</GenerateManifest>
     <GenerateManifest Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</GenerateManifest>
     <PlatformToolset>v141</PlatformToolset>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
     <UseIntelIPP>Parallel_Static</UseIntelIPP>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">

--- a/Builds/VisualStudio2017/Dexed_StandalonePlugin.vcxproj
+++ b/Builds/VisualStudio2017/Dexed_StandalonePlugin.vcxproj
@@ -21,7 +21,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{D47D7B71-12A0-0DE2-8C28-3F9C11907FBF}</ProjectGuid>
     <PlatformToolset>v141</PlatformToolset>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
     <UseIntelIPP>Parallel_Static</UseIntelIPP>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
@@ -31,7 +31,7 @@
     <WholeProgramOptimization>false</WholeProgramOptimization>
     <PlatformToolset>v141</PlatformToolset>
     <PlatformToolset>v141</PlatformToolset>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
     <UseIntelIPP>Parallel_Static</UseIntelIPP>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -40,7 +40,7 @@
     <WholeProgramOptimization>false</WholeProgramOptimization>
     <PlatformToolset>v141</PlatformToolset>
     <PlatformToolset>v141</PlatformToolset>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
     <UseIntelIPP>Parallel_Static</UseIntelIPP>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
@@ -49,7 +49,7 @@
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <PlatformToolset>v141</PlatformToolset>
     <PlatformToolset>v141</PlatformToolset>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
     <UseIntelIPP>Parallel_Static</UseIntelIPP>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
@@ -58,7 +58,7 @@
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <PlatformToolset>v141</PlatformToolset>
     <PlatformToolset>v141</PlatformToolset>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
     <UseIntelIPP>Parallel_Static</UseIntelIPP>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
@@ -68,7 +68,7 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros">
     <PlatformToolset>v141</PlatformToolset>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
     <UseIntelIPP>Parallel_Static</UseIntelIPP>
   </PropertyGroup>
   <PropertyGroup>
@@ -95,7 +95,7 @@
     <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(LibraryPath);$(SolutionDir)$(Platform)\$(Configuration)\Shared Code</LibraryPath>
     <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(LibraryPath);$(SolutionDir)$(Platform)\$(Configuration)\Shared Code</LibraryPath>
     <PlatformToolset>v141</PlatformToolset>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
     <UseIntelIPP>Parallel_Static</UseIntelIPP>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">

--- a/Builds/VisualStudio2017/Dexed_VST.vcxproj
+++ b/Builds/VisualStudio2017/Dexed_VST.vcxproj
@@ -21,7 +21,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{57D511ED-E818-C006-9D99-94BFEFDDBAB6}</ProjectGuid>
     <PlatformToolset>v141</PlatformToolset>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
     <UseIntelIPP>Parallel_Static</UseIntelIPP>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
@@ -31,7 +31,7 @@
     <WholeProgramOptimization>false</WholeProgramOptimization>
     <PlatformToolset>v141</PlatformToolset>
     <PlatformToolset>v141</PlatformToolset>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
     <UseIntelIPP>Parallel_Static</UseIntelIPP>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -40,7 +40,7 @@
     <WholeProgramOptimization>false</WholeProgramOptimization>
     <PlatformToolset>v141</PlatformToolset>
     <PlatformToolset>v141</PlatformToolset>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
     <UseIntelIPP>Parallel_Static</UseIntelIPP>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
@@ -49,7 +49,7 @@
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <PlatformToolset>v141</PlatformToolset>
     <PlatformToolset>v141</PlatformToolset>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
     <UseIntelIPP>Parallel_Static</UseIntelIPP>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
@@ -58,7 +58,7 @@
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <PlatformToolset>v141</PlatformToolset>
     <PlatformToolset>v141</PlatformToolset>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
     <UseIntelIPP>Parallel_Static</UseIntelIPP>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
@@ -68,7 +68,7 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros">
     <PlatformToolset>v141</PlatformToolset>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
     <UseIntelIPP>Parallel_Static</UseIntelIPP>
   </PropertyGroup>
   <PropertyGroup>
@@ -95,7 +95,7 @@
     <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(LibraryPath);$(SolutionDir)$(Platform)\$(Configuration)\Shared Code</LibraryPath>
     <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(LibraryPath);$(SolutionDir)$(Platform)\$(Configuration)\Shared Code</LibraryPath>
     <PlatformToolset>v141</PlatformToolset>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
     <UseIntelIPP>Parallel_Static</UseIntelIPP>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">

--- a/Source/DexedMidiKeyboardComponent.cpp
+++ b/Source/DexedMidiKeyboardComponent.cpp
@@ -1,0 +1,54 @@
+/**
+ *
+ * Copyright (c) 2013-2018 Pascal Gauthier.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+ *
+ */
+
+#include "DexedMidiKeyboardComponent.h"
+
+//==============================================================================
+DexedMidiKeyboardComponent::DexedMidiKeyboardComponent(MidiKeyboardState& s, Orientation o, bool showKey, bool preferKeyFocus)
+    : MidiKeyboardComponent(s, o), showKeyboard(showKey), preferMidiKeyboardFocus(preferKeyFocus) {
+}
+
+DexedMidiKeyboardComponent::~DexedMidiKeyboardComponent() {
+}
+
+void DexedMidiKeyboardComponent::setShowKeyboard(bool showKey) {
+    showKeyboard = showKey;
+}
+
+void DexedMidiKeyboardComponent::setPreferMidiKeyboardFocus(bool preferKeyFocus) {
+    preferMidiKeyboardFocus = preferKeyFocus;
+}
+
+bool DexedMidiKeyboardComponent::getShowKeyboard() {
+    return showKeyboard;
+}
+
+bool DexedMidiKeyboardComponent::getPreferMidiKeyboardFocus() {
+    return preferMidiKeyboardFocus;
+}
+
+void DexedMidiKeyboardComponent::focusLost(FocusChangeType focusChangeType) {
+    MidiKeyboardComponent::focusLost(focusChangeType);
+    
+    // Only keep the keyboard focused if it is set to be visible too.
+    if (showKeyboard == true && preferMidiKeyboardFocus == true) {
+        grabKeyboardFocus();
+    }
+}

--- a/Source/DexedMidiKeyboardComponent.h
+++ b/Source/DexedMidiKeyboardComponent.h
@@ -1,0 +1,49 @@
+/**
+ *
+ * Copyright (c) 2013-2017 Pascal Gauthier.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+ *
+ */
+
+#ifndef DEXEDMIDIKEYBOARDCOMPONENT_H_INCLUDED
+#define DEXEDMIDIKEYBOARDCOMPONENT_H_INCLUDED
+
+#include "../JuceLibraryCode/JuceHeader.h"
+
+class DexedMidiKeyboardComponent : public MidiKeyboardComponent
+{
+public:
+    DexedMidiKeyboardComponent(MidiKeyboardState& state, 
+                               Orientation orientation, 
+                               bool showKeyboard, 
+                               bool preferMidiKeyboardFocus);
+
+    ~DexedMidiKeyboardComponent();
+    
+    void setShowKeyboard(bool showKeyboard);
+    void setPreferMidiKeyboardFocus(bool preferMidiKeyboardFocus);
+    bool getShowKeyboard();
+    bool getPreferMidiKeyboardFocus();
+    void focusLost(FocusChangeType) override;
+
+private:
+    bool showKeyboard;
+    bool preferMidiKeyboardFocus;
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (DexedMidiKeyboardComponent)
+};
+
+#endif  // DEXEDMIDIKEYBOARDCOMPONENT_H_INCLUDED

--- a/Source/ParamDialog.cpp
+++ b/Source/ParamDialog.cpp
@@ -77,6 +77,8 @@ ParamDialog::ParamDialog ()
 
     addAndMakeVisible (showKeyboard = new ToggleButton ("showKeyboard"));
     showKeyboard->setButtonText (String());
+    addAndMakeVisible (preferMidiKeyboardFocus = new ToggleButton ("preferMidiKeyboardFocus"));
+    preferMidiKeyboardFocus->setButtonText (String());
 
     addAndMakeVisible (whlRange = new Slider ("whlRange"));
     whlRange->setRange (0, 99, 1);
@@ -188,6 +190,7 @@ ParamDialog::~ParamDialog()
     sysexChl = nullptr;
     engineReso = nullptr;
     showKeyboard = nullptr;
+    preferMidiKeyboardFocus = nullptr;
     whlRange = nullptr;
     ftRange = nullptr;
     brRange = nullptr;
@@ -255,7 +258,7 @@ void ParamDialog::paint (Graphics& g)
     }
 
     {
-        int x = 20, y = 156, width = 276, height = 23;
+        int x = 20, y = 196, width = 276, height = 23;
         String text (TRANS("Engine Resolution"));
         Colour fillColour = Colours::white;
         //[UserPaintCustomArguments] Customize the painting arguments here..
@@ -267,7 +270,7 @@ void ParamDialog::paint (Graphics& g)
     }
 
     {
-        int x = 22, y = 138, width = 306, height = 1;
+        int x = 22, y = 178, width = 306, height = 1;
         Colour fillColour = Colours::black;
         //[UserPaintCustomArguments] Customize the painting arguments here..
         //[/UserPaintCustomArguments]
@@ -276,7 +279,7 @@ void ParamDialog::paint (Graphics& g)
     }
 
     {
-        int x = 22, y = 195, width = 306, height = 1;
+        int x = 22, y = 235, width = 306, height = 1;
         Colour fillColour = Colours::black;
         //[UserPaintCustomArguments] Customize the painting arguments here..
         //[/UserPaintCustomArguments]
@@ -287,6 +290,18 @@ void ParamDialog::paint (Graphics& g)
     {
         int x = 20, y = 96, width = 276, height = 23;
         String text (TRANS("Show Keyboard"));
+        Colour fillColour = Colours::white;
+        //[UserPaintCustomArguments] Customize the painting arguments here..
+        //[/UserPaintCustomArguments]
+        g.setColour (fillColour);
+        g.setFont (Font (15.00f, Font::plain).withTypefaceStyle ("Regular"));
+        g.drawText (text, x, y, width, height,
+                    Justification::centredLeft, true);
+    }
+
+    {
+        int x = 20, y = 136, width = 276, height = 23;
+        String text (TRANS("Prefer Midi Keyboard Focus"));
         Colour fillColour = Colours::white;
         //[UserPaintCustomArguments] Customize the painting arguments here..
         //[/UserPaintCustomArguments]
@@ -416,8 +431,9 @@ void ParamDialog::resized()
     sysexIn->setBounds (104, 224, 224, 24);
     sysexOut->setBounds (104, 264, 224, 24);
     sysexChl->setBounds (264, 304, 72, 24);
-    engineReso->setBounds (160, 156, 168, 24);
+    engineReso->setBounds (160, 196, 168, 24);
     showKeyboard->setBounds (264, 96, 56, 24);
+    preferMidiKeyboardFocus->setBounds (264, 136, 56, 24);
     whlRange->setBounds (448, 16, 72, 24);
     ftRange->setBounds (448, 56, 72, 24);
     brRange->setBounds (448, 96, 72, 24);
@@ -583,7 +599,7 @@ void ParamDialog::buttonClicked (Button* buttonThatWasClicked)
 
 //[MiscUserCode] You can add your own definitions of your custom methods or any other code here...
 
-void ParamDialog::setDialogValues(Controllers &c, SysexComm &mgr, int reso, bool showKey) {
+void ParamDialog::setDialogValues(Controllers &c, SysexComm &mgr, int reso, bool showKey, bool preferKeyFocus) {
     pitchRange->setValue(c.values_[kControllerPitchRange]);
     pitchStep->setValue(c.values_[kControllerPitchStep]);
     sysexChl->setValue(mgr.getChl() + 1);
@@ -621,9 +637,10 @@ void ParamDialog::setDialogValues(Controllers &c, SysexComm &mgr, int reso, bool
 
     engineReso->setSelectedItemIndex(reso);
     showKeyboard->setToggleState(showKey, NotificationType::dontSendNotification);
+    preferMidiKeyboardFocus->setToggleState(preferKeyFocus, NotificationType::dontSendNotification);
 }
 
-bool ParamDialog::getDialogValues(Controllers &c, SysexComm &mgr, int *reso, bool *showKey) {
+bool ParamDialog::getDialogValues(Controllers &c, SysexComm &mgr, int *reso, bool *showKey, bool *preferKeyFocus) {
     bool ret = true;
 
     c.values_[kControllerPitchRange] = pitchRange->getValue();
@@ -659,6 +676,7 @@ bool ParamDialog::getDialogValues(Controllers &c, SysexComm &mgr, int *reso, boo
 
     *reso = engineReso->getSelectedItemIndex();
     *showKey = showKeyboard->getToggleState();
+    *preferKeyFocus = preferMidiKeyboardFocus->getToggleState();
     return ret;
 }
 

--- a/Source/ParamDialog.h
+++ b/Source/ParamDialog.h
@@ -47,8 +47,8 @@ public:
 
     //==============================================================================
     //[UserMethods]     -- You can add your own custom methods in this section.
-    void setDialogValues(Controllers &c, SysexComm &mgr, int reso, bool showKeyboard);
-    bool getDialogValues(Controllers &c, SysexComm &mgr, int *reso, bool *showKeyboard);
+    void setDialogValues(Controllers &c, SysexComm &mgr, int reso, bool showKeyboard, bool preferMidiKeyboardFocus);
+    bool getDialogValues(Controllers &c, SysexComm &mgr, int *reso, bool *showKeyboard, bool *preferMidiKeyboardFocus);
     //[/UserMethods]
 
     void paint (Graphics& g) override;
@@ -71,6 +71,7 @@ private:
     ScopedPointer<Slider> sysexChl;
     ScopedPointer<ComboBox> engineReso;
     ScopedPointer<ToggleButton> showKeyboard;
+    ScopedPointer<ToggleButton> preferMidiKeyboardFocus;
     ScopedPointer<Slider> whlRange;
     ScopedPointer<Slider> ftRange;
     ScopedPointer<Slider> brRange;

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -24,6 +24,7 @@
 #include "ParamDialog.h"
 #include "SysexComm.h"
 #include "Dexed.h"
+#include "DexedMidiKeyboardComponent.h"
 #include "math.h"
 #include <fstream>
 
@@ -32,7 +33,8 @@
 //==============================================================================
 DexedAudioProcessorEditor::DexedAudioProcessorEditor (DexedAudioProcessor* ownerFilter)
     : AudioProcessorEditor (ownerFilter),
-    midiKeyboard (ownerFilter->keyboardState, MidiKeyboardComponent::horizontalKeyboard),
+    midiKeyboard (ownerFilter->keyboardState, MidiKeyboardComponent::horizontalKeyboard, 
+        ownerFilter->showKeyboard, ownerFilter->preferMidiKeyboardFocus),
     cartManager(this)
 {
     setSize(866, ownerFilter->showKeyboard ? 674 : 581);
@@ -159,7 +161,8 @@ void DexedAudioProcessorEditor::parmShow() {
     AlertWindow window("","", AlertWindow::NoIcon, this);
     ParamDialog param;
     param.setColour(AlertWindow::backgroundColourId, Colour(0x32FFFFFF));
-    param.setDialogValues(processor->controllers, processor->sysexComm, tp, processor->showKeyboard);
+    param.setDialogValues(processor->controllers, processor->sysexComm, tp, processor->showKeyboard, 
+        processor->preferMidiKeyboardFocus);
 
     window.addCustomComponent(&param);
     window.addButton("OK", 0);
@@ -167,11 +170,14 @@ void DexedAudioProcessorEditor::parmShow() {
     if ( window.runModalLoop() != 0 )
         return;
     
-    bool ret = param.getDialogValues(processor->controllers, processor->sysexComm, &tp, &processor->showKeyboard);
+    bool ret = param.getDialogValues(processor->controllers, processor->sysexComm, &tp, &processor->showKeyboard, 
+        &processor->preferMidiKeyboardFocus);
     processor->setEngineType(tp);
     processor->savePreference();
     
     setSize(866, processor->showKeyboard ? 674 : 581);
+    midiKeyboard.setShowKeyboard(processor->showKeyboard);
+    midiKeyboard.setPreferMidiKeyboardFocus(processor->preferMidiKeyboardFocus);
     midiKeyboard.repaint();
     
     if ( ret == false ) {

--- a/Source/PluginEditor.h
+++ b/Source/PluginEditor.h
@@ -27,12 +27,13 @@
 #include "DXComponents.h"
 #include "DXLookNFeel.h"
 #include "CartManager.h"
+#include "DexedMidiKeyboardComponent.h"
 
 //==============================================================================
 /**
 */
 class DexedAudioProcessorEditor  : public AudioProcessorEditor, public ComboBox::Listener, public Timer {
-    MidiKeyboardComponent midiKeyboard;
+    DexedMidiKeyboardComponent midiKeyboard;
     OperatorEditor operators[6];
     Colour background;
     CartManager cartManager;

--- a/Source/PluginParam.cpp
+++ b/Source/PluginParam.cpp
@@ -767,6 +767,10 @@ void DexedAudioProcessor::loadPreference() {
         showKeyboard = prop.getIntValue( String("showKeyboard") );
     }
 
+    if ( prop.containsKey( String("preferMidiKeyboardFocus") ) ) {
+        preferMidiKeyboardFocus = prop.getIntValue( String("preferMidiKeyboardFocus") );
+    }
+
     if ( prop.containsKey( String("wheelMod") ) ) {
         controllers.wheel.parseConfig(prop.getValue(String("wheelMod")).toRawUTF8());
     }
@@ -800,6 +804,7 @@ void DexedAudioProcessor::savePreference() {
     prop.setValue(String("sysexChl"), sysexComm.getChl());
     
     prop.setValue(String("showKeyboard"), showKeyboard);
+    prop.setValue(String("preferMidiKeyboardFocus"), preferMidiKeyboardFocus);
 
     char mod_cfg[15];
     controllers.wheel.setConfig(mod_cfg);

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -94,6 +94,7 @@ DexedAudioProcessor::DexedAudioProcessor() {
     normalizeDxVelocity = false;
     sysexComm.listener = this;
     showKeyboard = true;
+    preferMidiKeyboardFocus = true;
     
     memset(&voiceStatus, 0, sizeof(VoiceStatus));
     setEngineType(DEXED_ENGINE_MARKI);

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -134,6 +134,7 @@ public :
     bool forceRefreshUI;
     float vuSignal;
     bool showKeyboard;
+    bool preferMidiKeyboardFocus;
     int getEngineType();
     void setEngineType(int rs);
     


### PR DESCRIPTION
While browsing through patches and carts, I figured it would be very convenient for the computer keyboard to remain focussed on the on-screen MIDI keyboard component so that I could play notes as I clicked through patches. So I've added this functionality, as well as a toggle to configure it on and off. It was mostly for myself, but I figured that others might find it useful too!

Please let me know if you require any changes!

![DexedParameterDialog](https://user-images.githubusercontent.com/7825549/58386675-78b69680-8003-11e9-9bb7-760699b19e05.png)
