### PR TITLE
Add MIDI portamento

### DIFF
--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -236,6 +236,8 @@ public :
     static File dexedCartDir;
     
     Value lastCCUsed;
+    int lastKeyDown;
+
 private:
     //==============================================================================
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (DexedAudioProcessor)

--- a/Source/msfa/controllers.h
+++ b/Source/msfa/controllers.h
@@ -21,6 +21,7 @@
 #include "../Dexed.h"
 #include <stdio.h>
 #include <string.h>
+#include <math.h>
 
 #ifdef _WIN32
 #define snprintf _snprintf
@@ -88,6 +89,8 @@ public:
     int breath_cc;
     int foot_cc;
     int modwheel_cc;
+    bool portamento_enable_cc;
+    int portamento_cc;
     
     int masterTune;
     
@@ -118,7 +121,7 @@ public:
         
         TRACE("controllers refresh>>> amp_mod %d pitch_mod %d", amp_mod, pitch_mod);
     }
-    
+
     FmCore *core;
 };
 

--- a/Source/msfa/dx7note.h
+++ b/Source/msfa/dx7note.h
@@ -37,7 +37,7 @@ struct VoiceStatus {
 class Dx7Note {
 public:
     Dx7Note();
-    void init(const uint8_t patch[156], int midinote, int velocity);
+    void init(const uint8_t patch[156], int midinote, int velocity, int srcnote, int porta);
     
     // Note: this _adds_ to the buffer. Interesting question whether it's
     // worth it...
@@ -72,6 +72,9 @@ private:
     int algorithm_;
     int pitchmoddepth_;
     int pitchmodsens_;
+
+    int porta_rateindex_;
+    int32_t porta_curpitch_[6];
 };
 
 #endif  // SYNTH_DX7NOTE_H_

--- a/Source/msfa/porta.cc
+++ b/Source/msfa/porta.cc
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 Jean Pierre Cimalando.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <math.h>
+#include "porta.h"
+#include "synth.h"
+
+void Porta::init_sr(double sampleRate)
+{
+    // compute portamento for CC 7-bit range
+
+    for (unsigned int i = 0; i < 128; ++i) {
+        // number of semitones travelled
+        double sps = 350.0 * pow(2.0, -0.062 * i);  // per second
+        double spf = sps / sampleRate;              // per frame
+        double spp = spf * N;                       // per period
+        const int step = (1 << 24) / 12;
+        rates[i] = (int32_t)(0.5f + step * spp);    // to pitch units
+    }
+}
+
+int32_t Porta::rates[128];

--- a/Source/msfa/porta.h
+++ b/Source/msfa/porta.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 Jean Pierre Cimalando.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SYNTH_PORTA_H_
+#define SYNTH_PORTA_H_
+
+#include <stdint.h>
+
+struct Porta {
+public:
+    static void init_sr(double sampleRate);
+    static int32_t rates[128];
+};
+
+#endif  // SYNTH_PORTA_H_


### PR DESCRIPTION
I saw the TODO item on portamento, and I implemented something.

It has a formula based on measurements I did quite long ago on Yamaha SY77 portamento delays.
DX7 may or may not have used identical values. I don't know DX7, this should be checked.

It's the kind of operation obtained when portamento is configured in poly mode.
It implements the CC 5 and 65.