### PR TITLE
Workaround for crash initializing the ALSA client

### DIFF
--- a/JuceLibraryCode/AppConfig.h
+++ b/JuceLibraryCode/AppConfig.h
@@ -18,6 +18,8 @@
 
 //#define JUCE_CORETEXT_AVAILABLE 0
 
+#define JUCE_ALSA_MIDI_NAME "Dexed"
+
 // [END_USER_CODE_SECTION]
 
 /*


### PR DESCRIPTION
#132
works around the null pointer error.