### PR TITLE
Fix misc. typos

### DIFF
--- a/Source/DXLookNFeel.h
+++ b/Source/DXLookNFeel.h
@@ -33,7 +33,7 @@ public:
     Image imageSwitchOperator;
     Image imageOperator, imageGlobal;
 
-    /* overriden methods */
+    /* overridden methods */
     virtual void drawRotarySlider(Graphics &g, int x, int y, int width, int height, float sliderPosProportional, float rotaryStartAngle, float rotaryEndAngle,  Slider &slider ) override;
     virtual void drawToggleButton(Graphics& g, ToggleButton& button, bool isMouseOverButton, bool isButtonDown) override;
     virtual void drawLinearSliderBackground (Graphics&, int x, int y, int width, int height,

--- a/Source/EngineMkI.cpp
+++ b/Source/EngineMkI.cpp
@@ -339,7 +339,7 @@ void EngineMkI::render(int32_t *output, FmOpParams *params, int algorithm, int32
                             op++; // ignore next operator;
                             break;
                         default:
-                            // one operator feedback, normal proces
+                            // one operator feedback, normal process
                             compute_fb(outptr, param.phase, param.freq, gain1, gain2, fb_buf, feedback_shift, add);
                             break;
                     }

--- a/Source/GlobalEditor.cpp
+++ b/Source/GlobalEditor.cpp
@@ -28,7 +28,7 @@
 //[MiscUserDefs] You can add your own user definitions and misc code here...
 
 /**
- * Ugly but usefull midi monitor to know if you are really sending/receiving something from the DX7
+ * Ugly but useful midi monitor to know if you are really sending/receiving something from the DX7
  * If the midi is not configured this component wont show up
  *
 class MidiMonitor : public Component {

--- a/Source/PluginData.cpp
+++ b/Source/PluginData.cpp
@@ -101,7 +101,7 @@ void Cartridge::packProgram(uint8_t *src, int idx, String name, char *opSwitch) 
 
 /**
  * This function normalize data that comes from corrupted sysex.
- * It used to avoid engine crashing upon extrem values
+ * It used to avoid engine crashing upon extreme values
  */
 char normparm(char value, char max, int id) {
     if ( value <= max && value >= 0 )
@@ -360,7 +360,7 @@ void DexedAudioProcessor::setStateInformation(const void* source, int sizeInByte
     ScopedPointer<XmlElement> root(getXmlFromBinary(source, sizeInBytes));
     
     if (root == nullptr) {
-        TRACE("unkown state format");
+        TRACE("unknown state format");
         return;
     }
     
@@ -405,7 +405,7 @@ void DexedAudioProcessor::setStateInformation(const void* source, int sizeInByte
     var program = blobSet["program"];
     
     if ( sysex_blob.isVoid() || program.isVoid() ) {
-        TRACE("unkown serialized blob data");
+        TRACE("unknown serialized blob data");
         return;
     }
     

--- a/Source/PluginData.h
+++ b/Source/PluginData.h
@@ -92,7 +92,7 @@ public:
     
     /**
      * Loads sysex stream
-     * Returns 0 if it was parsed sucessfully
+     * Returns 0 if it was parsed successfully
      * Returns -1 if it cannot open the stream
      */
     int load(InputStream &fis) {
@@ -105,7 +105,7 @@ public:
     
     /**
      * Loads sysex buffer
-     * Returns 0 if it was parsed sucessfully
+     * Returns 0 if it was parsed successfully
      * Returns 1 if sysex checksum didn't match
      * Returns 2 if no sysex data found, probably random data
      */
@@ -183,7 +183,7 @@ public:
         int sz = fis->read(buffer, 65535);
         delete fis;
         
-        // if the file is smaller than 4104, it probably needs to be overriden.
+        // if the file is smaller than 4104, it probably needs to be overridden.
         if ( sz <= 4104 ) {
             return f.replaceWithData(voiceData, SYSEX_SIZE);
         }

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -198,7 +198,7 @@ void DexedAudioProcessorEditor::timerCallback() {
         return;
 
     for(int i=0;i<6;i++) {
-        operators[i].updateGain(sqrt(processor->voiceStatus.amp[5 - i]) / 8196);        // TODO: FUGLY !!!! change this sqrt nonsens
+        operators[i].updateGain(sqrt(processor->voiceStatus.amp[5 - i]) / 8196);        // TODO: FUGLY !!!! change this sqrt nonsense
         operators[i].updateEnvPos(processor->voiceStatus.ampStep[5 - i]);
     }
     global.updatePitchPos(processor->voiceStatus.pitchStep);

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -421,7 +421,7 @@ void DexedAudioProcessor::keydown(uint8_t pitch, uint8_t velo) {
     if ( monoMode ) {
         for(int i=0; i<MAX_ACTIVE_NOTES; i++) {            
             if ( voices[i].live ) {
-                // all keys are up, only transfert signal
+                // all keys are up, only transfer signal
                 if ( ! voices[i].keydown ) {
                     voices[i].live = false;
                     voices[note].dx7_note->transferSignal(*voices[i].dx7_note);

--- a/Source/msfa/dx7note.cc
+++ b/Source/msfa/dx7note.cc
@@ -305,7 +305,7 @@ void Dx7Note::peekVoiceStatus(VoiceStatus &status) {
 }
 
 /**
- * Used in monophonic mode to transfert voice state from different notes
+ * Used in monophonic mode to transfer voice state from different notes
  */
 void Dx7Note::transferState(Dx7Note &src) {
     for (int i=0;i<6;i++) {

--- a/Source/msfa/env.cc
+++ b/Source/msfa/env.cc
@@ -155,7 +155,7 @@ void Env::update(const int r[4], const int l[4], int ol, int rate_scaling) {
     outlevel_ = ol;
     rate_scaling_ = rate_scaling;
     if ( down_ ) {
-        // for now we simply reset ourselve at level 3
+        // for now we simply reset ourselves at level 3
         int newlevel = levels_[2];
         int actuallevel = scaleoutlevel(newlevel) >> 1;
         actuallevel = (actuallevel << 6) - 4256;


### PR DESCRIPTION
Found via `codespell -q 3 -S ./JuceLibraryCode`