### PR TITLE
Basic UI scaling for HiDPI screens and some rendering optimization

### DIFF
--- a/Source/GlobalEditor.cpp
+++ b/Source/GlobalEditor.cpp
@@ -493,6 +493,7 @@ void GlobalEditor::sliderValueChanged (Slider* sliderThatWasMoved)
     else if (sliderThatWasMoved == algo)
     {
         //[UserSliderCode_algo] -- add your slider handling code here..
+        algoDisplay->repaint();
         //[/UserSliderCode_algo]
     }
     else if (sliderThatWasMoved == output)
@@ -619,6 +620,7 @@ void GlobalEditor::setSystemMessage(String msg) {
 
 void GlobalEditor::setParamMessage(String msg) {
     lcdDisplay->paramMsg = msg;
+    lcdDisplay->repaint();
 }
 
 void GlobalEditor::updateDisplay() {

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -32,10 +32,15 @@
 //==============================================================================
 DexedAudioProcessorEditor::DexedAudioProcessorEditor (DexedAudioProcessor* ownerFilter)
     : AudioProcessorEditor (ownerFilter),
-    midiKeyboard (ownerFilter->keyboardState, MidiKeyboardComponent::horizontalKeyboard),
-    cartManager(this)
+      midiKeyboard (ownerFilter->keyboardState, MidiKeyboardComponent::horizontalKeyboard),
+      cartManager(this),
+      dpiScaleFactor(1.0)
 {
-    setSize(866, ownerFilter->showKeyboard ? 674 : 581);
+    if(Desktop::getInstance().getDisplays().getMainDisplay().dpi > HIGH_DPI_THRESHOLD) {
+        dpiScaleFactor = 1.5;
+    }
+    setScaleFactor(dpiScaleFactor);
+    setSize(866 * dpiScaleFactor, dpiScaleFactor * (ownerFilter->showKeyboard ? 674 : 581));
 
     processor = ownerFilter;
     
@@ -171,7 +176,8 @@ void DexedAudioProcessorEditor::parmShow() {
     processor->setEngineType(tp);
     processor->savePreference();
     
-    setSize(866, processor->showKeyboard ? 674 : 581);
+    setSize(866 * dpiScaleFactor, (processor->showKeyboard ? 674 : 581) * dpiScaleFactor);
+        
     midiKeyboard.repaint();
     
     if ( ret == false ) {

--- a/Source/PluginEditor.h
+++ b/Source/PluginEditor.h
@@ -38,6 +38,10 @@ class DexedAudioProcessorEditor  : public AudioProcessorEditor, public ComboBox:
     CartManager cartManager;
 
     SharedResourcePointer<DXLookNFeel> lookAndFeel;
+
+    static const uint8_t HIGH_DPI_THRESHOLD = 128;
+    float dpiScaleFactor;
+
 public:
     DexedAudioProcessor *processor;
     GlobalEditor global;

--- a/Source/PluginParam.cpp
+++ b/Source/PluginParam.cpp
@@ -197,7 +197,6 @@ public :
             return;
         }
         editor->global.setParamMessage(getValueDisplay());
-        editor->global.repaint();
     }
 };
 
@@ -394,7 +393,6 @@ void CtrlDX::updateDisplayName() {
     String msg;
     msg << label << " = " << getValueDisplay();
     editor->global.setParamMessage(msg);
-    editor->global.repaint();
 }
 
 
@@ -670,7 +668,6 @@ float DexedAudioProcessor::getParameter(int index) {
 
 void DexedAudioProcessor::setParameter(int index, float newValue) {
     ctrl[index]->setValueHost(newValue);
-    forceRefreshUI = true;
 }
 
 int DexedAudioProcessor::getNumPrograms() {


### PR DESCRIPTION
This patch implements basic UI scaling in a simple way: if the current display DPI is above a threshold, everything is scaled by 1.5 including the size of the window. This works great on my Retina Macbook and makes everything much more usable.

In the process of doing this I noticed some UI slow down coming from excessive repainting as parameters are changing. The end result with my changes is more responsive feeling knobs and sliders. I'm pretty sure that every part of the UI is still repainting as expected but that could use a quick review to make sure I didn't miss anything.

Cheers!