### PR TITLE
Make scripts agnostic to invocation path

### DIFF
--- a/scripts/build-lin.sh
+++ b/scripts/build-lin.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
+SCRIPTS_PATH=`dirname $(readlink -f $0)`
+DEXED_PATH=${SCRIPTS_PATH%/scripts}
+
 export CONFIG=Release
-cd ../Builds/Linux && make
-
-
+cd $DEXED_PATH/Builds/Linux && make

--- a/scripts/build-mac-so.sh
+++ b/scripts/build-mac-so.sh
@@ -1,3 +1,6 @@
 #!/bin/sh
 
-xcodebuild build -target "Dexed - Standalone Plugin" -configuration Release -project ../Builds/MacOSX/Dexed.xcodeproj
+SCRIPTS_PATH=`dirname $(readlink -f $0)`
+DEXED_PATH=${SCRIPTS_PATH%/scripts}
+
+xcodebuild build -target "Dexed - Standalone Plugin" -configuration Release -project $DEXED_PATH/Builds/MacOSX/Dexed.xcodeproj

--- a/scripts/build-mac.sh
+++ b/scripts/build-mac.sh
@@ -1,3 +1,6 @@
 #!/bin/sh
 
-xcodebuild build -configuration Release -project ../Builds/MacOSX/Dexed.xcodeproj
+SCRIPTS_PATH=`dirname $(readlink -f $0)`
+DEXED_PATH=${SCRIPTS_PATH%/scripts}
+
+xcodebuild build -configuration Release -project $DEXED_PATH/Builds/MacOSX/Dexed.xcodeproj

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -3,6 +3,9 @@
 # This shell script does, more or less, waht the azure pipelines do for you if you
 # just want a clean build
 
+SCRIPTS_PATH=`dirname $(readlink -f $0)`
+DEXED_PATH=${SCRIPTS_PATH%/scripts}
+
 OS=`uname -s`
 JOS=win
 
@@ -16,10 +19,9 @@ fi
 
 
 if [ ! -f "assets/JUCE/LICENSE.md" ]; then
-    ./scripts/get-juce.sh
+    $DEXED_PATH/scripts/get-juce.sh
 fi
 
-./scripts/projuce-${JOS}.sh
-./scripts/build-${JOS}.sh
-./scripts/package-${JOS}.sh
-
+$DEXED_PATH/scripts/projuce-${JOS}.sh
+$DEXED_PATH/scripts/build-${JOS}.sh
+$DEXED_PATH/scripts/package-${JOS}.sh

--- a/scripts/get-juce.sh
+++ b/scripts/get-juce.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
 JUCE_VERSION=6.0.0
+SCRIPTS_PATH=`dirname $(readlink -f $0)`
+DEXED_PATH=${SCRIPTS_PATH%/scripts}
 OS=`uname -s`
 JOS=windows
 
@@ -14,7 +16,7 @@ fi
 
 echo Downloading for $JOS
 
-cd ..
+cd $DEXED_PATH
 mkdir -p assets
 curl -L -o assets/juce-${JUCE_VERSION}-${JOS}.zip https://github.com/juce-framework/JUCE/releases/download/${JUCE_VERSION}/juce-${JUCE_VERSION}-${JOS}.zip
 cd assets && unzip juce-${JUCE_VERSION}-${JOS}.zip

--- a/scripts/package-lin.sh
+++ b/scripts/package-lin.sh
@@ -5,6 +5,11 @@ BUILDDATE=`date +%Y%m%d`
 VERSION="${GIT_TAG}-${BUILDDATE}"
 UN=`uname -a`
 
+SCRIPTS_PATH=`dirname $(readlink -f $0)`
+DEXED_PATH=${SCRIPTS_PATH%/scripts}
+
+cd $DEXED_PATH
+
 rm -rf Builds/Linux/Dexed-Nightly
 mkdir -p Builds/Linux/Dexed-Nightly
 
@@ -27,4 +32,3 @@ cat Dexed-Nightly/BuildInfo.txt
 
 pwd
 tar cvzf ../../products/Dexed_ubuntu_linux_${VERSION}.tgz Dexed-Nightly
-

--- a/scripts/package-mac.sh
+++ b/scripts/package-mac.sh
@@ -4,6 +4,11 @@ GIT_TAG=`git rev-parse --short HEAD`
 BUILDDATE=`date +%Y%m%d`
 VERSION="${GIT_TAG}-${BUILDDATE}"
 
+SCRIPTS_PATH=`dirname $(readlink -f $0)`
+DEXED_PATH=${SCRIPTS_PATH%/scripts}
+
+cd $DEXED_PATH
+
 rm -rf Builds/MacOSX/Dexed-Nightly
 rm -rf *dmg
 mkdir -p Builds/MacOSX/Dexed-Nightly
@@ -17,4 +22,3 @@ tar cf - Dexed.app/* | ( cd ../../Dexed-nightly ; tar xf - )
 cd ../../../..
 
 hdiutil create products/Dexed_macOS_${VERSION}.dmg -ov -volname "Dexed_${VERSION}" -fs HFS+ -srcfolder Builds/MacOSX/Dexed-nightly/
-

--- a/scripts/projuce-lin-vst2.sh
+++ b/scripts/projuce-lin-vst2.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
 
+SCRIPTS_PATH=`dirname $(readlink -f $0)`
+DEXED_PATH=${SCRIPTS_PATH%/scripts}
+
 if [ -z $VST2SDK_DIR ]; then
     echo "VST2SDK_DIR is not set. Please point it to a directory containing the VST2 SDK"
     exit 1
 else
+   cd $DEXED_PATH
+
    sed -e 's/,buildVST3/,buildVST,buildVST3/' Dexed.jucer | \
 	sed -e "s@VST2SDK_DIR@${VST2SDK_DIR}@" | \
 	sed -e 's/PLUGINHOST_VST="0"/PLUGINHOST_VST="1"/' | \
@@ -13,4 +18,3 @@ else
    assets/JUCE/Projucer --resave Dexed.jucer
    mv Dexed-orig.jucer Dexed.jucer
 fi
-

--- a/scripts/projuce-lin.sh
+++ b/scripts/projuce-lin.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+SCRIPTS_PATH=`dirname $(readlink -f $0)`
+DEXED_PATH=${SCRIPTS_PATH%/scripts}
+
 ## TODO: Check assets exists
-cd ..
+cd $DEXED_PATH
 assets/JUCE/Projucer --resave Dexed.jucer

--- a/scripts/projuce-mac.sh
+++ b/scripts/projuce-mac.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+SCRIPTS_PATH=`dirname $(readlink -f $0)`
+DEXED_PATH=${SCRIPTS_PATH%/scripts}
+
 ## TODO: Check assets exists
-cd ..
+cd $DEXED_PATH
 assets/JUCE/Projucer.app/Contents/MacOS/Projucer --resave Dexed.jucer

--- a/scripts/set-version.sh
+++ b/scripts/set-version.sh
@@ -1,9 +1,13 @@
 #!/bin/sh
 
+SCRIPTS_PATH=`dirname $(readlink -f $0)`
+DEXED_PATH=${SCRIPTS_PATH%/scripts}
+
+cd $DEXED_PATH
 GIT_TAG=`git rev-parse --short HEAD`
 BUILDDATE=`date +%Y%m%d`
 VERSION="${GIT_TAG}-BETA-surge-synth-team"
 echo "Setting dexed version to '$VERSION'"
 
-sed -e "s/#define DEXED_ID .*/#define DEXED_ID \"${VERSION}\"/" Source/Dexed.h > Source/Dexed_versioned.h
-mv Source/Dexed_versioned.h Source/Dexed.h
+sed -e "s/#define DEXED_ID .*/#define DEXED_ID \"${VERSION}\"/" $DEXED_PATH/Source/Dexed.h > $DEXED_PATH/Source/Dexed_versioned.h
+mv $DEXED_PATH/Source/Dexed_versioned.h $DEXED_PATH/Source/Dexed.h


### PR DESCRIPTION
A number of users attempting to build Dexed on linux have run into trouble, and developed various workarounds (#221 #225). It'd be nice if all the scripts worked no matter where they were run from, so that no matter how a user attempts to build them, they'll be successful.

To achieve that, this PR modifies each relevant install script to locate the absolute path of dexed (`DEXED_PATH`) and perform any actions relative to that.

### Testing

I've tested this on Linux, but I don't have the VST2 SDK, so I haven't tested `scripts/projuce-lin-vst2.sh`. I also don't have a Mac, so I haven't tested the mac scripts.

Shared scripts:
- [ ] set-version.sh (tested by author on Linux)
- [ ] release-notes.sh (tested by author on Linux)
- [ ] get-juce.sh (tested by author on Linux)
- [ ] build.sh (tested by author on Linux)

Linux scripts:
- [ ] projuce-lin.sh (tested by author on Linux)
- [ ] projuce-lin-vst2.sh
- [ ] build-lin.sh (tested by author on Linux)
- [ ] package-lin.sh (tested by author on Linux)

Mac scripts:
- [ ] projuce-mac.sh
- [ ] build-mac.sh
- [ ] build-mac-so.sh
- [ ] package-mac.sh