### PR TITLE
Update get-juce.sh to use the latest JUCE version

### DIFF
--- a/scripts/get-juce.sh
+++ b/scripts/get-juce.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-JUCE_VERSION=6.0.0
+JUCE_VERSION=6.0.1
 OS=`uname -s`
 JOS=windows
 


### PR DESCRIPTION
The linux nightly build is broken on Ubuntu due to a JUCE Makefile error; the correct std version is not being set. 
Error: `unordered_map’ in namespace ‘std’ does not name a template type` which indicates the `std=c++17` compiler flag is not being correctly set. Manually bumping the version number from 6.0.0->6.0.1 fixes this.