### PR TITLE
Clean up release note language

### DIFF
--- a/scripts/release-notes.sh
+++ b/scripts/release-notes.sh
@@ -1,19 +1,12 @@
 #!/bin/bash
 
 cat <<- EOH
-# Automated build of surge-synth-team dexed fork
+# Automated build of Dexed
 
-This is a build of our fork of dexed from the very top of our git repository.
-Currently available for Win and Mac as VST3/Standalone/AU (Mac). Linux standalone
-coming soon.
-
-This is beta software. If you want a production version of dexed you should find 
-the original. This may not work and may be generally bad for you and your system. But
-we are using it and moving towards a point where we think we could do something like
-a solid release.
-
-If you understand that, download below, if not, perhaps hop in our slack and
-chat with us? 
+This is an automated build of Dexed from the head of our github
+repository. This software is the absolute latest version of our
+source code and as such may still include work in progress features
+and other issues needing resolution. 
 
 EOH
 date


### PR DESCRIPTION
Hi! I'm super glad you got the azure pipelines running. Some folks over on KVR today discovered the changes we've collaborated on and I saw that you got nightlies up and running. I've adjusted our website to push people to your nightlies and so on. Very exciting!

One thing I noticed was the release notes still say surge and so on. This PR is just a tiny wording change which will update the text in the nightlies at asb2m10/dexed.

Oh and folks were very excited about a tunable dexed. Fun stuff! 