### PR TITLE
Remove memcpy overwriting normalised parameters

### DIFF
--- a/Source/PluginData.cpp
+++ b/Source/PluginData.cpp
@@ -129,7 +129,6 @@ void Cartridge::unpackProgram(uint8_t *unpackPgm, int idx) {
             unpackPgm[op * 21 + i] = normparm(currparm, 99, i);
         }
         
-        memcpy(unpackPgm + op * 21, bulk + op * 17, 11);
         char leftrightcurves = bulk[op * 17 + 11]&0xF; // bits 4-7 don't care per sysex spec
         unpackPgm[op * 21 + 11] = leftrightcurves & 3;
         unpackPgm[op * 21 + 12] = (leftrightcurves >> 2) & 3;


### PR DESCRIPTION
The memcpy appeared to be overwriting the previously normalised parameters unpacked in the for loop above it. This pull request removes the memcpy under the assumption that the intended behaviour was to normalise the values instead of copying them straight into the unpacked program.