### PR TITLE
Improve scaling for HighDPI displays

### DIFF
--- a/Source/GlobalEditor.cpp
+++ b/Source/GlobalEditor.cpp
@@ -66,7 +66,7 @@ public:
     HyperlinkButton dexed;
     HyperlinkButton surge;
 
-    AboutBox(Component *parent) : DialogWindow("About", Colour(0xFF000000), true), 
+    AboutBox(Component *parent) : DialogWindow("About", Colour(0xFF000000), true),
             dexed("https://asb2m10.github.io/dexed/", URL("https://asb2m10.github.io/dexed/")),
             surge("https://surge-synthesizer.github.io/", URL("https://surge-synthesizer.github.io/")) {
         setUsingNativeTitleBar(false);
@@ -76,11 +76,11 @@ public:
         centreAroundComponent(parent, getWidth(), getHeight());
 
         dexed.setColour(HyperlinkButton::ColourIds::textColourId, Colour(0xFF4ea097));
-        dexed.setJustificationType(Justification::left);        
+        dexed.setJustificationType(Justification::left);
         dexed.setBounds(18, 433, getWidth() - 36, 30);
         addAndMakeVisible(&dexed);
         surge.setColour(HyperlinkButton::ColourIds::textColourId, Colour(0xFF4ea097));
-        surge.setJustificationType(Justification::left);        
+        surge.setJustificationType(Justification::left);
         surge.setBounds(18, 458, getWidth() - 36, 30);
         addAndMakeVisible(&surge);
     }

--- a/Source/ParamDialog.cpp
+++ b/Source/ParamDialog.cpp
@@ -291,19 +291,6 @@ ParamDialog::ParamDialog ()
 
     pitchRangeUp->setBounds (168, 16, 72, 24);
 
-    scalingFactor.reset (new ComboBox ("scalingFactor"));
-    addAndMakeVisible (scalingFactor.get());
-    scalingFactor->setEditableText (false);
-    scalingFactor->setJustificationType (Justification::centredLeft);
-    scalingFactor->setTextWhenNothingSelected (String());
-    scalingFactor->setTextWhenNoChoicesAvailable (TRANS("(no choices)"));
-    scalingFactor->addItem (TRANS("100 %"), 1);
-    scalingFactor->addItem (TRANS("150 %"), 2);
-    scalingFactor->addListener (this);
-
-    scalingFactor->setBounds (236, 136, 90, 24);
-
-
     //[UserPreSize]
     //[/UserPreSize]
 
@@ -367,7 +354,6 @@ ParamDialog::~ParamDialog()
     mpeEnabled = nullptr;
     transposeHelp = nullptr;
     pitchRangeUp = nullptr;
-    scalingFactor = nullptr;
 
 
     //[Destructor]. You can add your own custom destruction code here..
@@ -667,18 +653,6 @@ void ParamDialog::paint (Graphics& g)
                     Justification::centredLeft, true);
     }
 
-    {
-        int x = 20, y = 136, width = 276, height = 23;
-        String text (TRANS("UI Scaling"));
-        Colour fillColour = Colours::white;
-        //[UserPaintCustomArguments] Customize the painting arguments here..
-        //[/UserPaintCustomArguments]
-        g.setColour (fillColour);
-        g.setFont (Font (15.00f, Font::plain).withTypefaceStyle ("Regular"));
-        g.drawText (text, x, y, width, height,
-                    Justification::centredLeft, true);
-    }
-
     //[UserPaint] Add your own custom painting code here..
     if ( ! JUCEApplication::isStandaloneApp() ) {
         g.setColour (Colours::white);
@@ -785,11 +759,6 @@ void ParamDialog::comboBoxChanged (ComboBox* comboBoxThatHasChanged)
     {
         //[UserComboBoxCode_engineReso] -- add your combo box handling code here..
         //[/UserComboBoxCode_engineReso]
-    }
-    else if (comboBoxThatHasChanged == scalingFactor.get())
-    {
-        //[UserComboBoxCode_scalingFactor] -- add your combo box handling code here..
-        //[/UserComboBoxCode_scalingFactor]
     }
 
     //[UsercomboBoxChanged_Post]
@@ -998,10 +967,6 @@ void ParamDialog::setDialogValues(Controllers &c, SysexComm &mgr, int reso, bool
     engineReso->setSelectedItemIndex(reso);
     showKeyboard->setToggleState(showKey, NotificationType::dontSendNotification);
 
-    if ( dpiScaleFactor == 1.5 )
-        scalingFactor->setSelectedItemIndex(1);
-    else
-        scalingFactor->setSelectedItemIndex(0);
 }
 
 bool ParamDialog::getDialogValues(Controllers &c, SysexComm &mgr, int *reso, bool *showKey, float *dpiScaleFactor) {
@@ -1047,13 +1012,6 @@ bool ParamDialog::getDialogValues(Controllers &c, SysexComm &mgr, int *reso, boo
     *reso = engineReso->getSelectedItemIndex();
     *showKey = showKeyboard->getToggleState();
 
-    switch(scalingFactor->getSelectedItemIndex()) {
-        case 1 :
-            *dpiScaleFactor = 1.5;
-            break;
-        default:
-            *dpiScaleFactor = 1.0;
-    }
     return ret;
 }
 
@@ -1146,9 +1104,6 @@ BEGIN_JUCER_METADATA
           fontname="Default font" fontsize="15.0" kerning="0.0" bold="0"
           italic="0" justification="33"/>
     <TEXT pos="240 16 20 23" fill="solid: ffffffff" hasStroke="0" text="dn"
-          fontname="Default font" fontsize="15.0" kerning="0.0" bold="0"
-          italic="0" justification="33"/>
-    <TEXT pos="20 136 276 23" fill="solid: ffffffff" hasStroke="0" text="UI Scaling"
           fontname="Default font" fontsize="15.0" kerning="0.0" bold="0"
           italic="0" justification="33"/>
   </BACKGROUND>
@@ -1273,9 +1228,6 @@ BEGIN_JUCER_METADATA
           max="48.0" int="1.0" style="RotaryVerticalDrag" textBoxPos="TextBoxLeft"
           textBoxEditable="1" textBoxWidth="80" textBoxHeight="20" skewFactor="1.0"
           needsCallback="1"/>
-  <COMBOBOX name="scalingFactor" id="843af1bae988d4d6" memberName="scalingFactor"
-            virtualName="" explicitFocusOrder="0" pos="236 136 90 24" editable="0"
-            layout="33" items="100 %&#10;150 %" textWhenNonSelected="" textWhenNoItems="(no choices)"/>
 </JUCER_COMPONENT>
 
 END_JUCER_METADATA

--- a/Source/ParamDialog.h
+++ b/Source/ParamDialog.h
@@ -113,7 +113,6 @@ private:
     std::unique_ptr<LightedToggleButton> mpeEnabled;
     std::unique_ptr<ImageButton> transposeHelp;
     std::unique_ptr<Slider> pitchRangeUp;
-    std::unique_ptr<ComboBox> scalingFactor;
 
 
     //==============================================================================

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -39,7 +39,7 @@ DexedAudioProcessorEditor::DexedAudioProcessorEditor (DexedAudioProcessor* owner
     setSize(WINDOW_SIZE_X, (ownerFilter->showKeyboard ? WINDOW_SIZE_Y : 581));
 
     processor = ownerFilter;
-    
+
     lookAndFeel->setDefaultLookAndFeel(lookAndFeel);
     background = lookAndFeel->background;
 
@@ -47,30 +47,30 @@ DexedAudioProcessorEditor::DexedAudioProcessorEditor (DexedAudioProcessor* owner
     addAndMakeVisible(&(operators[0]));
     operators[0].setBounds(2, 1, 287, 218);
     operators[0].bind(processor, 0);
-    
+
     addAndMakeVisible(&(operators[1]));
     operators[1].setBounds(290, 1, 287, 218);
     operators[1].bind(processor, 1);
-    
+
     addAndMakeVisible(&(operators[2]));
     operators[2].setBounds(578, 1, 287, 218);
     operators[2].bind(processor, 2);
-    
+
     addAndMakeVisible(&(operators[3]));
     operators[3].setBounds(2, 219, 287, 218);
     operators[3].bind(processor, 3);
-    
+
     addAndMakeVisible(&(operators[4]));
     operators[4].setBounds(290, 219, 287, 218);
     operators[4].bind(processor, 4);
-    
+
     addAndMakeVisible(&(operators[5]));
     operators[5].setBounds(578, 219, 287, 218);
     operators[5].bind(processor, 5);
 
     // add the midi keyboard component..
     addAndMakeVisible (&midiKeyboard);
-    
+
     // The DX7 is a badass on the bass, keep it that way
     midiKeyboard.setLowestVisibleKey(24);
 
@@ -79,14 +79,14 @@ DexedAudioProcessorEditor::DexedAudioProcessorEditor (DexedAudioProcessor* owner
     addAndMakeVisible(&global);
     global.setBounds(2,436,864,144);
     global.bind(this);
-    
+
     global.setMonoState(processor->isMonoMode());
-    
+
     rebuildProgramCombobox();
     global.programs->addListener(this);
-    
+
     addChildComponent(&cartManager);
-    
+
     updateUI();
     startTimer(100);
 }
@@ -98,13 +98,13 @@ DexedAudioProcessorEditor::~DexedAudioProcessorEditor() {
 }
 
 //==============================================================================
-void DexedAudioProcessorEditor::paint (Graphics& g) {    
+void DexedAudioProcessorEditor::paint (Graphics& g) {
     g.setColour(background);
     g.fillRoundedRectangle(0.0f, 0.0f, (float) getWidth(), (float) getHeight(), 0);
 }
 
 void DexedAudioProcessorEditor::cartShow() {
-    stopTimer();    
+    stopTimer();
     cartManager.resetActiveSysex();
     cartManager.setBounds(4, 2, 859, 576);
     cartManager.setVisible(true);
@@ -116,14 +116,14 @@ void DexedAudioProcessorEditor::loadCart(File file) {
     Cartridge cart;
 
     int rc = cart.load(file);
-    
+
     if ( rc < 0 ) {
         AlertWindow::showMessageBoxAsync (AlertWindow::WarningIcon,
                                           "Error",
                                           "Unable to open: " + file.getFullPathName());
         return;
     }
-    
+
     if ( rc != 0 ) {
         rc = AlertWindow::showOkCancelBox(AlertWindow::QuestionIcon, "Unable to find DX7 sysex cartridge in file",
                                           "This sysex file is not for the DX7 or it is corrupted. "
@@ -131,13 +131,13 @@ void DexedAudioProcessorEditor::loadCart(File file) {
         if ( rc == 0 )
             return;
     }
-    
+
     processor->loadCartridge(cart);
     rebuildProgramCombobox();
     processor->setCurrentProgram(0);
     global.programs->setSelectedId(processor->getCurrentProgram()+1, dontSendNotification);
     processor->updateHostDisplay();
-    
+
     processor->activeFileCartridge = file;
 }
 
@@ -157,7 +157,7 @@ void DexedAudioProcessorEditor::saveCart() {
 void DexedAudioProcessorEditor::tuningShow() {
     auto te = new TuningShow();
     te->setTuning( processor->synthTuningState->getTuning() );
-    
+
     DialogWindow::LaunchOptions options;
     options.content.setOwned(te);
     options.dialogTitle = "Current Tuning";
@@ -210,11 +210,10 @@ void DexedAudioProcessorEditor::parmShow() {
                                    bool ret = param->getDialogValues(this->processor->controllers, this->processor->sysexComm, &tpo, &this->processor->showKeyboard, &this->processor->dpiScaleFactor);
                                    this->processor->setEngineType(tpo);
                                    this->processor->savePreference();
-                                   
-                                   this->setScaleFactor(this->processor->dpiScaleFactor);
+
                                    this->setSize(WINDOW_SIZE_X, (processor->showKeyboard ? WINDOW_SIZE_Y : 581));
                                    this->midiKeyboard.repaint();
-                                   
+
                                    if ( ret == false ) {
                                        AlertWindow::showMessageBoxAsync(AlertWindow::WarningIcon, "Midi Interface", "Error opening midi ports");
                                    }
@@ -238,7 +237,7 @@ void DexedAudioProcessorEditor::timerCallback() {
         processor->forceRefreshUI = false;
         updateUI();
     }
-    
+
     if ( ! processor->peekVoiceStatus() )
         return;
 
@@ -248,7 +247,7 @@ void DexedAudioProcessorEditor::timerCallback() {
     }
     global.updatePitchPos(processor->voiceStatus.pitchStep);
     global.updateVu(processor->vuSignal);
-}   
+}
 
 void DexedAudioProcessorEditor::updateUI() {
     for(int i=0;i<processor->ctrl.size();i++) {
@@ -263,22 +262,22 @@ void DexedAudioProcessorEditor::updateUI() {
 
 void DexedAudioProcessorEditor::rebuildProgramCombobox() {
     global.programs->clear(dontSendNotification);
-    
+
     processor->currentCart.getProgramNames(processor->programNames);
-    
+
     for(int i=0;i<processor->getNumPrograms();i++) {
         String id;
         id << (i+1) << ". " << processor->getProgramName(i);
         global.programs->addItem(id, i+1);
     }
-    
+
     global.programs->setSelectedId(processor->getCurrentProgram()+1, dontSendNotification);
-    
+
     String name = Cartridge::normalizePgmName((const char *) processor->data+145);
     cartManager.setActiveProgram(processor->getCurrentProgram(), name);
     if ( name != processor->getProgramName(processor->getCurrentProgram()) )
         global.programs->setText("**. " + name, dontSendNotification);
-    
+
     cartManager.resetActiveSysex();
 }
 
@@ -288,10 +287,10 @@ void DexedAudioProcessorEditor::storeProgram() {
     File *externalFile = NULL;
 
     bool activeCartridgeFound = processor->activeFileCartridge.exists();
-    
+
     while (true) {
         String msg;
-        
+
         if ( externalFile == NULL ) {
             if ( activeCartridgeFound )
                 msg = "Store program to current (" + processor->activeFileCartridge.getFileName() + ") / new cartridge";
@@ -300,7 +299,7 @@ void DexedAudioProcessorEditor::storeProgram() {
         } else {
             msg = "Store program to " + externalFile->getFileName();
         }
-        
+
         AlertWindow dialog("Store Program", msg, AlertWindow::NoIcon, this);
         dialog.addTextEditor("Name", currentName, String("Name"), false);
         // TODO: fix the name length to 10
@@ -315,10 +314,10 @@ void DexedAudioProcessorEditor::storeProgram() {
             saveAction.add("Store program and create a new copy of the .syx cartridge");
             if ( activeCartridgeFound )
                 saveAction.add("Store program and overwrite current .syx cartridge");
-        
+
             dialog.addComboBox("SaveAction", saveAction, "Store Action");
         }
-                
+
         dialog.addButton("OK", 0, KeyPress(KeyPress::returnKey));
         dialog.addButton("CANCEL", 1, KeyPress(KeyPress::escapeKey));
         dialog.addButton("EXTERNAL FILE", 2, KeyPress());
@@ -328,7 +327,7 @@ void DexedAudioProcessorEditor::storeProgram() {
             FileChooser fc("Destination Sysex", processor->dexedCartDir, "*.syx;*.SYX;*.*", 1);
 
             if ( fc.browseForFileToOpen() ) {
-                if ( externalFile != NULL ) 
+                if ( externalFile != NULL )
                     delete externalFile;
 
                 externalFile = new File(fc.getResults().getReference(0));
@@ -341,7 +340,7 @@ void DexedAudioProcessorEditor::storeProgram() {
         if ( response == 0 ) {
             TextEditor *name = dialog.getTextEditor("Name");
             ComboBox *dest = dialog.getComboBoxComponent("Dest");
-            
+
             int programNum = dest->getSelectedItemIndex();
             String programName(name->getText());
             if ( programName.length() > 10 ) {
@@ -354,9 +353,9 @@ void DexedAudioProcessorEditor::storeProgram() {
                 rebuildProgramCombobox();
                 processor->setCurrentProgram(programNum);
                 processor->updateHostDisplay();
-                
+
                 int action = dialog.getComboBoxComponent("SaveAction")->getSelectedItemIndex();
-                if ( action > 0 ) {                  
+                if ( action > 0 ) {
                     File destination = processor->activeFileCartridge;
                     if ( action == 1 ) {
                         FileChooser fc("Destination Sysex", processor->dexedCartDir, "*.syx;*.SYX", 1);
@@ -364,7 +363,7 @@ void DexedAudioProcessorEditor::storeProgram() {
                             break;
                         destination = fc.getResult();
                     }
-                    
+
                     processor->currentCart.saveVoice(destination);
                     processor->activeFileCartridge = destination;
                 }
@@ -392,14 +391,14 @@ public :
         this->target = target;
         setMessage("Mapping: " + String(target->label) + ", waiting for midi controller change (CC) message...");
         addButton("CANCEL", -1);
-        editor->processor->lastCCUsed.setValue(-1);        
+        editor->processor->lastCCUsed.setValue(-1);
         editor->processor->lastCCUsed.addListener(this);
     }
-    
+
     ~MidiCCListener() {
         editor->processor->lastCCUsed.removeListener(this);
     }
-    
+
     void valueChanged(Value &value) {
         int cc = value.getValue();
         editor->processor->mappedMidiCC.remove(cc);
@@ -417,7 +416,7 @@ void DexedAudioProcessorEditor::discoverMidiCC(Ctrl *ctrl) {
 bool DexedAudioProcessorEditor::isInterestedInFileDrag (const StringArray &files)
 {
     if( files.size() != 1 ) return false;
-    
+
     for( auto i = files.begin(); i != files.end(); ++i )
     {
         if( i->endsWithIgnoreCase( ".scl" ) || i->endsWithIgnoreCase( ".kbm" ) )

--- a/Source/PluginParam.cpp
+++ b/Source/PluginParam.cpp
@@ -49,7 +49,7 @@ public:
     CtrlDXLabel(String name, int steps, int offset, StringArray &labels) : CtrlDX(name, steps, offset, 0) {
         this->labels = labels;
     };
-    
+
     String getValueDisplay() {
         return labels[getValue()];
     }
@@ -59,12 +59,12 @@ class CtrlDXTranspose : public CtrlDX {
 public:
     CtrlDXTranspose(String name, int steps, int offset) : CtrlDX(name, steps, offset, 0) {
     };
-    
+
     String getValueDisplay() {
         String ret ;
         int value = getValue();
         return ret << (value - 24);
-#if 0        
+#if 0
         switch(value % 12) {
             case 0: ret << "C"; break;
             case 1: ret << "C#"; break;
@@ -80,7 +80,7 @@ public:
             case 11: ret << "B"; break;
         }
         return ret << (value/12+1);
-#endif        
+#endif
     }
 };
 
@@ -88,7 +88,7 @@ class CtrlDXSwitch : public CtrlDX {
 public:
     CtrlDXSwitch(String name, int steps, int offset) : CtrlDX(name, steps, offset, 0) {
     };
-    
+
     String getValueDisplay() {
         return getValue() ? String("ON") : String("OFF");
     }
@@ -98,7 +98,7 @@ class CtrlDXOpMode : public CtrlDX {
 public:
     CtrlDXOpMode(String name, int steps, int offset) : CtrlDX(name, steps, offset, 0) {
     };
-    
+
     String getValueDisplay() {
         return getValue() ? String("FIXED") : String("RATIO");
     }
@@ -108,7 +108,7 @@ class CtrlDXBreakpoint : public CtrlDX {
 public:
     CtrlDXBreakpoint(String name, int steps, int offset) : CtrlDX(name, steps, offset, 0) {
     };
-    
+
     String getValueDisplay() {
         const char *breakNames[] = {"A", "A#", "B", "C", "C#", "D", "D#", "E", "F", "F#", "G", "G#"};
         String ret;
@@ -120,29 +120,29 @@ public:
 class CtrlTune : public Ctrl {
 public:
     DexedAudioProcessor *processor;
-    
+
     CtrlTune(String name, DexedAudioProcessor *owner) : Ctrl(name) {
         processor = owner;
     }
-    
+
     float getValueHost() {
         // meh. good enough for now
         int32_t tune = processor->controllers.masterTune / (1.0/12);
         tune = (tune >> 11) + 0x2000;
         return (float)tune / 0x4000;
     }
-    
+
     void setValueHost(float v) {
         int32_t tune = (v * 0x4000) - 0x2000;
         processor->controllers.masterTune = ((float) (tune << 11)) * (1.0/12);
     }
-    
+
     String getValueDisplay() {
         String display;
         display << (getValueHost() * 2) -1;
         return display;
     }
-    
+
     void updateComponent() {
         if (slider != NULL) {
             slider->setValue(getValueHost(), dontSendNotification);
@@ -158,31 +158,31 @@ public :
         processor = owner;
         value = switchValue;
     }
-    
+
     void setValueHost(float f) {
         if ( f == 0 )
             *value = '0';
         else
             *value = '1';
         updateDisplayName();
-        
+
         // the value is based on the controller
         parent->setDxValue(155, -1);
     }
-    
+
     float getValueHost() {
         if ( *value == '0' )
             return 0;
         else
             return 1;
     }
-    
+
     String getValueDisplay() {
         String ret;
         ret << label << " " << (*value == '0' ? "OFF" : "ON");
         return ret;
     }
-    
+
     void updateComponent() {
         if (button != NULL) {
             if (*value == '0') {
@@ -192,7 +192,7 @@ public :
             }
         }
     }
-    
+
     void updateDisplayName() {
         DexedAudioProcessorEditor *editor = (DexedAudioProcessorEditor *) parent->getActiveEditor();
         if ( editor == NULL ) {
@@ -445,43 +445,43 @@ void CtrlDX::updateComponent() {
 void DexedAudioProcessor::initCtrl() {
     setupStartupCart();
     currentProgram = 0;
-    
+
     fxCutoff.reset(new CtrlFloat("Cutoff", &fx.uiCutoff));
     ctrl.add(fxCutoff.get());
-    
+
     fxReso.reset(new CtrlFloat("Resonance", &fx.uiReso));
     ctrl.add(fxReso.get());
-    
+
     output.reset(new CtrlFloat("Output", &fx.uiGain));
     ctrl.add(output.get());
-    
+
     tune.reset(new CtrlTune("MASTER TUNE ADJ", this));
     ctrl.add(tune.get());
-    
+
     algo.reset(new CtrlDX("ALGORITHM", 31, 134, 1));
     ctrl.add(algo.get());
-    
+
     feedback.reset(new CtrlDX("FEEDBACK", 7, 135));
     ctrl.add(feedback.get());
-    
+
     oscSync.reset(new CtrlDXSwitch("OSC KEY SYNC", 1, 136));
     ctrl.add(oscSync.get());
-    
+
     lfoRate.reset(new CtrlDX("LFO SPEED", 99, 137));
     ctrl.add(lfoRate.get());
-    
+
     lfoDelay.reset(new CtrlDX("LFO DELAY", 99, 138));
     ctrl.add(lfoDelay.get());
-    
+
     lfoPitchDepth.reset(new CtrlDX("LFO PM DEPTH", 99, 139));
     ctrl.add(lfoPitchDepth.get());
-    
+
     lfoAmpDepth.reset(new CtrlDX("LFO AM DEPTH", 99, 140));
     ctrl.add(lfoAmpDepth.get());
-    
+
     lfoSync.reset(new CtrlDXSwitch("LFO KEY SYNC", 1, 141));
     ctrl.add(lfoSync.get());
-    
+
     StringArray lbl;
     lbl.add("TRIANGE");
     lbl.add("SAW DOWN");
@@ -489,16 +489,16 @@ void DexedAudioProcessor::initCtrl() {
     lbl.add("SQUARE");
     lbl.add("SINE");
     lbl.add("S&HOLD");
-    
+
     lfoWaveform.reset(new CtrlDXLabel("LFO WAVE", 5, 142, lbl));
     ctrl.add(lfoWaveform.get());
-    
+
     transpose.reset(new CtrlDXTranspose("TRANSPOSE", 48, 144));
     ctrl.add(transpose.get());
-    
+
     pitchModSens.reset(new CtrlDX("P MODE SENS.", 7, 143));
     ctrl.add(pitchModSens.get());
-    
+
     for (int i=0;i<4;i++) {
         String rate;
         rate << "PITCH EG RATE " << (i+1);
@@ -512,13 +512,13 @@ void DexedAudioProcessor::initCtrl() {
         pitchEgLevel[i].reset(new CtrlDX(level, 99, 130+i));
         ctrl.add(pitchEgLevel[i].get());
     }
-    
+
     StringArray keyScaleLabels;
     keyScaleLabels.add("-LN");
     keyScaleLabels.add("-EX");
     keyScaleLabels.add("+EX");
     keyScaleLabels.add("+LN");
-    
+
     // fill operator values;
     for (int i = 0; i < 6; i++) {
         //// In the Sysex, OP6 comes first, then OP5...
@@ -527,20 +527,20 @@ void DexedAudioProcessor::initCtrl() {
         String opName;
         opName << "OP" << (opVal + 1);
 
-        for (int j = 0; j < 4; j++) {     
+        for (int j = 0; j < 4; j++) {
             String opRate;
             opRate << opName << " EG RATE " << (j + 1);
             opCtrl[opVal].egRate[j].reset(new CtrlDX(opRate, 99, opTarget + j));
             ctrl.add(opCtrl[opVal].egRate[j].get());
         }
-    
-        for (int j = 0; j < 4; j++) {        
+
+        for (int j = 0; j < 4; j++) {
             String opLevel;
             opLevel << opName << " EG LEVEL " << (j + 1);
             opCtrl[opVal].egLevel[j].reset(new CtrlDX(opLevel, 99, opTarget + j + 4));
             ctrl.add(opCtrl[opVal].egLevel[j].get());
         }
-    
+
         String opVol;
         opVol << opName << " OUTPUT LEVEL";
         opCtrl[opVal].level.reset(new CtrlDX(opVol, 99, opTarget + 16));
@@ -605,13 +605,13 @@ void DexedAudioProcessor::initCtrl() {
         velModSens << opName << " KEY VELOCITY";
         opCtrl[opVal].velModSens.reset(new CtrlDX(velModSens, 7, opTarget + 15));
         ctrl.add(opCtrl[opVal].velModSens.get());
-        
+
         String opSwitchLabel;
         opSwitchLabel << opName << " SWITCH";
         opCtrl[opVal].opSwitch.reset(new CtrlOpSwitch(opSwitchLabel, (char *)&(controllers.opSwitch)+(5-i), this));
         ctrl.add(opCtrl[opVal].opSwitch.get());
     }
-    
+
     for (int i=0; i < ctrl.size(); i++) {
         ctrl[i]->idx = i;
         ctrl[i]->parent = this;
@@ -640,14 +640,14 @@ void DexedAudioProcessor::setDxValue(int offset, int v) {
     // MIDDLE C (transpose)
     if (offset == 144)
         panic();
-    
+
     if (!sendSysexChange)
         return;
-    
+
     uint8 msg[7] = { 0xF0, 0x43, 0x10, offset > 127, 0, (uint8) v, 0xF7 };
     msg[2] = 0x10 | sysexComm.getChl();
     msg[4] = offset & 0x7F;
-    
+
     if ( sysexComm.isOutputActive() ) {
         //TRACE("SENDING SYSEX: %.2X%.2X %.2X%.2X %.2X%.2X %.2X", msg[0], msg[1], msg[2], msg[3], msg[4], msg[5], msg[6]);
         sysexComm.send(MidiMessage(msg,7));
@@ -689,23 +689,23 @@ void DexedAudioProcessor::setCurrentProgram(int index) {
         TRACE("skipping save, storage recall to close");
         return;
     }
-    
+
     panic();
-    
+
     index = index > 31 ? 31 : index;
     currentCart.unpackProgram(data, index);
     unpackOpSwitch(0x3F);
     lfo.reset(data + 137);
     currentProgram = index;
     triggerAsyncUpdate();
-    
+
     // reset parameter display
     DexedAudioProcessorEditor *editor = (DexedAudioProcessorEditor *) getActiveEditor();
     if ( editor == NULL ) {
         return;
     }
     editor->global.setParamMessage("");
-    
+
     panic();
 }
 
@@ -728,43 +728,49 @@ const String DexedAudioProcessor::getParameterText(int index) {
 
 void DexedAudioProcessor::loadPreference() {
     File propFile = DexedAudioProcessor::dexedAppDir.getChildFile("Dexed.xml");
+    {
+      std::stringstream message;
+      message << "Reading config from " << propFile.getFullPathName();
+      Logger::writeToLog(message.str());
+    }
     PropertiesFile::Options prefOptions;
     PropertiesFile prop(propFile, prefOptions);
-    
+
     if ( ! prop.isValidFile() ) {
         return;
     }
-    
+
+
     if ( prop.containsKey( String("normalizeDxVelocity") ) ) {
         normalizeDxVelocity = prop.getIntValue( String("normalizeDxVelocity") );
     }
-    
+
     if ( prop.containsKey( String("pitchRange") ) ) {
         controllers.values_[kControllerPitchRangeUp] = prop.getIntValue( String("pitchRange") );
     }
-    
+
     if ( prop.containsKey( String("pitchRangeDn") ) ) {
         controllers.values_[kControllerPitchRangeDn] = prop.getIntValue( String("pitchRangeDn") );
     } else {
         controllers.values_[kControllerPitchRangeDn] = controllers.values_[kControllerPitchRangeUp];
     }
-    
+
     if ( prop.containsKey( String("pitchStep") ) ) {
         controllers.values_[kControllerPitchStep] = prop.getIntValue( String("pitchStep") );
     }
-    
+
     if ( prop.containsKey( String("sysexIn") ) ) {
         sysexComm.setInput( prop.getValue("sysexIn") );
     }
-    
+
     if ( prop.containsKey( String("sysexOut") ) ) {
         sysexComm.setOutput( prop.getValue("sysexOut") );
     }
-    
+
     if ( prop.containsKey( String("sysexChl") ) ) {
         sysexComm.setChl( prop.getIntValue( String("sysexChl") ) );
     }
-    
+
     if ( prop.containsKey( String("engineType") ) ) {
         setEngineType(prop.getIntValue(String("engineType")));
     }
@@ -776,23 +782,23 @@ void DexedAudioProcessor::loadPreference() {
     if ( prop.containsKey( String("wheelMod") ) ) {
         controllers.wheel.parseConfig(prop.getValue(String("wheelMod")).toRawUTF8());
     }
-    
+
     if ( prop.containsKey( String("footMod") ) ) {
         controllers.foot.parseConfig(prop.getValue(String("footMod")).toRawUTF8());
     }
-    
+
     if ( prop.containsKey( String("breathMod") ) ) {
         controllers.breath.parseConfig(prop.getValue(String("breathMod")).toRawUTF8());
     }
-    
+
     if ( prop.containsKey( String("aftertouchMod") ) ) {
         controllers.at.parseConfig(prop.getValue(String("aftertouchMod")).toRawUTF8());
     }
-    
+
     if ( prop.containsKey( String("dpiScaleFactor") ) ) {
         dpiScaleFactor = prop.getDoubleValue(String("dpiScaleFactor"));
     }
-    
+
     controllers.refresh();
 }
 
@@ -800,17 +806,17 @@ void DexedAudioProcessor::savePreference() {
     File propFile = DexedAudioProcessor::dexedAppDir.getChildFile("Dexed.xml");
     PropertiesFile::Options prefOptions;
     PropertiesFile prop(propFile, prefOptions);
-    
+
     prop.setValue(String("normalizeDxVelocity"), normalizeDxVelocity);
     prop.setValue(String("pitchRange"), controllers.values_[kControllerPitchRangeUp]); // for backwards compat
     prop.setValue(String("pitchRangeUp"), controllers.values_[kControllerPitchRangeUp]);
     prop.setValue(String("pitchRangeDn"), controllers.values_[kControllerPitchRangeDn]);
     prop.setValue(String("pitchStep"), controllers.values_[kControllerPitchStep]);
-    
+
     prop.setValue(String("sysexIn"), sysexComm.getInput());
     prop.setValue(String("sysexOut"), sysexComm.getOutput());
     prop.setValue(String("sysexChl"), sysexComm.getChl());
-    
+
     prop.setValue(String("showKeyboard"), showKeyboard);
 
     char mod_cfg[15];
@@ -822,10 +828,10 @@ void DexedAudioProcessor::savePreference() {
     prop.setValue(String("breathMod"), mod_cfg);
     controllers.at.setConfig(mod_cfg);
     prop.setValue(String("aftertouchMod"), mod_cfg);
-    
+
     prop.setValue(String("engineType"), (int) engineType);
     prop.setValue(String("dpiScaleFactor"), dpiScaleFactor);
-    
+
     prop.save();
 }
 


### PR DESCRIPTION
Currently semi-manual scaling applies only to the main window (excluding elements in its title bar).  In particular, the window where you can manually override the scaling factor is itself not scaled.  Also, although the 150% scaling is a slight improvement, it's not enough for all High-DPI displays.  This change switches to fully-automatic scaling for the full application, based on the DPI returned for the main display.  It makes all the text of the whole application readable for the first time on my laptop display (where I needed 220% scaling).