### PR TITLE
Adjust feedback for algorithm 32 in Mk I engine

### DIFF
--- a/Source/EngineMkI.cpp
+++ b/Source/EngineMkI.cpp
@@ -338,6 +338,10 @@ void EngineMkI::render(int32_t *output, FmOpParams *params, int algorithm, int32
                             params[1].phase += params[1].freq << LG_N;  // yuk, hack, we already processed op-5
                             op++; // ignore next operator;
                             break;
+                        case 31 :
+                            // one operator feedback, process exception for ALGO 32
+                            compute_fb(outptr, param.phase, param.freq, gain1, gain2, fb_buf, min((feedback_shift+2), 16), add);
+                            break;
                         default:
                             // one operator feedback, normal process
                             compute_fb(outptr, param.phase, param.freq, gain1, gain2, fb_buf, feedback_shift, add);


### PR DESCRIPTION
Pushing the feedback value up to 7 in algorithm 32 results in digital noise, see issue asb2m10#146.
That's not how the original DX7 behaves.
This patch tries to fix this issue by scaling the feedback value for algorithm 32. It sounds
much closer to the (at least my) DX7 Mk I and doesn't produce the digital noise any more.

In direct comparison, at feedback value 7 it sounds a bit brighter than my original DX7.
I tried different scalings (e.g. feedback_shift+3) which sounded a bit too muffled.
So overall (feedback_shift+2) sounds closest to my DX7.

This might need further investigaion but for now I think that this scaling is much better than
the digital noise currently produced.