### PR TITLE
Fix a Linux build error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ assets/
 products/
 
 .DS_Store
+build*/
+.cache/

--- a/Source/CartManager.cpp
+++ b/Source/CartManager.cpp
@@ -137,8 +137,8 @@ CartManager::CartManager(DexedAudioProcessorEditor *editor) : Component("CartMan
 
 CartManager::~CartManager() {
     timeSliceThread->stopThread(500);
-    cartBrowserList.release();
-    timeSliceThread.release();
+    cartBrowserList;
+    timeSliceThread;
 }
 
 void CartManager::paint(Graphics &g) {

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -773,7 +773,7 @@ AudioProcessorEditor* DexedAudioProcessor::createEditor() {
         }
     }
     
-    const juce::Rectangle rect(DexedAudioProcessorEditor::WINDOW_SIZE_X * dpiScaleFactor,DexedAudioProcessorEditor::WINDOW_SIZE_Y * dpiScaleFactor);
+    const juce::Rectangle<int> rect(DexedAudioProcessorEditor::WINDOW_SIZE_X * dpiScaleFactor,DexedAudioProcessorEditor::WINDOW_SIZE_Y * dpiScaleFactor);
     bool displayFound = false;
     
     // validate if there is really a display that can show the complete plugin size


### PR DESCRIPTION
`dexed/Source/PluginProcessor.cpp:776:11: error: invalid use of template-name ‘juce::Rectangle’`

see also https://github.com/asb2m10/dexed/issues/324#issuecomment-1086916677

+ stop some leakage in CartManager