### PR TITLE
More CMake changes and less warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,3 +40,27 @@ option(JUCE_BUILD_EXAMPLES "Build JUCE Examples" OFF)
 add_subdirectory(libs)
 add_subdirectory(Resources)
 add_subdirectory(Source)
+
+# uncomment to enable warnings are errors,
+# suppress warnings (or remove when fixed)
+# or add -Wall, -Wextra or specific warnings as you see fit 
+if (APPLE)
+target_compile_options(${PROJECT_NAME} PUBLIC
+        #-Werror
+        #-Wno-deprecated-declarations
+        #-Wno-unused-value
+        )
+elseif(UNIX AND NOT APPLE)
+target_compile_options(${PROJECT_NAME} PUBLIC
+        -Werror
+        -Wno-deprecated-declarations
+        -Wno-unused-value
+        )
+else()
+target_compile_options(${PROJECT_NAME} PUBLIC
+        #/WX # Warnings are errors
+        #/wd4996 # deprecated-declarations
+        # (I don't know all the windows warning numbers
+        #  replace cxxx with /wdxxx to supress them)
+        )
+endif()

--- a/README_cmake.md
+++ b/README_cmake.md
@@ -39,14 +39,21 @@ build-dexed/Source/Dexed_artefacts/
 ```
 
 JUCE will be downloaded during the `submodule update` step.
-So there's no need invoke the ./scripts/get-juce.sh script.
+So there's no need to invoke the ./scripts/get-juce.sh script.
 
-IF you want to try building with a different (local) JUCE version, you can do so with
+If you want to try building with a different (local) JUCE version, you can do so with
 ```
 cmake -Bbuild-blah -DDEXED_JUCE_PATH=/location/of/JUCE
 ```
 as the first cmake command.
 
+CMake will use whatever is the default compiler on your system.
+If you want to switch to a different one you can do:
+```
+# example using clang
+#
+cmake -Bbuild -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
+```
 
 
 

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -57,13 +57,10 @@ target_compile_definitions(${BaseTargetName} PUBLIC
     JUCE_JACK=1
     JUCE_MODAL_LOOPS_PERMITTED=1 # needed for FileBrowser in CartManager
     JUCE_DISPLAY_SPLASH_SCREEN=0
-
 )
 
-target_link_libraries(${BaseTargetName} PRIVATE
-    juce::juce_recommended_config_flags
-    juce::juce_recommended_lto_flags
-    juce::juce_recommended_warning_flags
+target_link_libraries(${BaseTargetName} 
+PRIVATE
     juce::juce_audio_basics
     juce::juce_audio_devices
     juce::juce_audio_formats
@@ -79,6 +76,7 @@ target_link_libraries(${BaseTargetName} PRIVATE
     surgesynthteam_tuningui
     tuning-library
     DexedResources
+PUBLIC
+    juce::juce_recommended_config_flags
+    juce::juce_recommended_lto_flags
 )
-
-

--- a/Source/PluginFx.cpp
+++ b/Source/PluginFx.cpp
@@ -37,7 +37,7 @@ inline static float tptpc(float& state,float inp,float cutoff) {
 }
 
 inline static float tptlpupw(float & state , float inp , float cutoff , float srInv) {
-	cutoff = (cutoff * srInv)*juce::float_Pi;
+	cutoff = (cutoff * srInv)*juce::MathConstants<float>::pi;
 	double v = (inp - state) * cutoff / (1 + cutoff);
 	double res = v + state;
 	state = res + v;
@@ -72,7 +72,7 @@ void PluginFx::init(int sr) {
     rcor24 = (970.0 / 44000)*rcrate;
     rcor24Inv = 1 / rcor24;
     
-    bright = tan((sampleRate*0.5f-10) * juce::float_Pi * sampleRateInv);
+    bright = tan((sampleRate*0.5f-10) * juce::MathConstants<float>::pi * sampleRateInv);
     
     R = 1;
 	rcor = (480.0 / 44000)*rcrate;
@@ -127,7 +127,7 @@ void PluginFx::process(float *work, int sampleSize) {
         R24 = 3.5 * rReso;
         
         float cutoffNorm = logsc(uiCutoff,60,19000);
-        rCutoff = (float)tan(cutoffNorm * sampleRateInv * juce::float_Pi);
+        rCutoff = (float)tan(cutoffNorm * sampleRateInv * juce::MathConstants<float>::pi);
             
         pCutoff = uiCutoff;
         pReso = uiReso;

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -766,7 +766,7 @@ AudioProcessorEditor* DexedAudioProcessor::createEditor() {
     AudioProcessorEditor* editor = new DexedAudioProcessorEditor (this);
 
     if ( dpiScaleFactor == -1 ) {
-        if ( Desktop::getInstance().getDisplays().getMainDisplay().dpi > HIGH_DPI_THRESHOLD ) {
+        if ( Desktop::getInstance().getDisplays().getPrimaryDisplay()->dpi > HIGH_DPI_THRESHOLD ) {
             dpiScaleFactor = 1.5;
         } else {
             dpiScaleFactor = 1.0;

--- a/Source/msfa/tuning.cc
+++ b/Source/msfa/tuning.cc
@@ -39,8 +39,8 @@ struct SCLAndKBMTuningState : public TuningState {
         return tuning.logScaledFrequencyForMidiNote( midinote ) * step + base;
     }
 
-    virtual int scale_length() { return tuning.scale.count; }
-    virtual std::string display_tuning_str() { return "SCL KBM Tuning"; }
+    virtual int scale_length() override { return tuning.scale.count; }
+    virtual std::string display_tuning_str() override { return "SCL KBM Tuning"; }
 
     virtual Tunings::Tuning &getTuning() override { return tuning; }
 


### PR DESCRIPTION
- remove `juce_recommended_warning_flags`
  This otherwise builds with `-Wall -Wextra` which shows a lot of less- or unimportant
  warnings with the important ones lost inbetween, plus you can not supress warnings.
- move recommended lto and config flags to public as per juce recomendation
- fix a few warnings
- update tuningui submodule

In total this brings the 2k+ displayed warnings down to managable 28
which are a few deprecated-declarations and two unused values.

- add configurable option to add or supress warnings to CMakeLists.txt
  turned on as an example for linux, which in this example supresses the remaining warnings
  while newly introduced warnings will error.