### PR TITLE
Use buses API for channel configuration

### DIFF
--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -63,7 +63,8 @@
 #endif
 
 //==============================================================================
-DexedAudioProcessor::DexedAudioProcessor() {
+DexedAudioProcessor::DexedAudioProcessor()
+    : AudioProcessor(BusesProperties().withOutput("output", AudioChannelSet::stereo(), true)) {
 #ifdef DEBUG
     
     // avoid creating the log file if it is in standalone mode
@@ -721,6 +722,11 @@ bool DexedAudioProcessor::isInputChannelStereoPair (int index) const {
 
 bool DexedAudioProcessor::isOutputChannelStereoPair (int index) const {
     return true;
+}
+
+bool DexedAudioProcessor::isBusesLayoutSupported(const BusesLayout &layouts) const {
+    return layouts.getMainOutputChannelSet() == AudioChannelSet::mono()
+                || layouts.getMainOutputChannelSet() == AudioChannelSet::stereo();
 }
 
 bool DexedAudioProcessor::acceptsMidi() const {

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -213,6 +213,7 @@ public :
     const String getOutputChannelName (int channelIndex) const;
     bool isInputChannelStereoPair (int index) const;
     bool isOutputChannelStereoPair (int index) const;
+    bool isBusesLayoutSupported (const BusesLayout& layouts) const;
 
     bool acceptsMidi() const;
     bool producesMidi() const;


### PR DESCRIPTION
Without configuration the plugin would expose a multitude of input and output channels, at least when used
in Carla. The projucer's pluginChannelConfigs option cannot be carried over to the cmake build system
so, following [1], channel configuration is done using the buses API .

[1] https://github.com/juce-framework/JUCE/blob/master/docs/CMake%20API.md