### PR TITLE
Respect MIDI channel on control change mappings

### DIFF
--- a/Source/PluginData.cpp
+++ b/Source/PluginData.cpp
@@ -472,6 +472,11 @@ void DexedAudioProcessor::setStateInformation(const void* source, int sizeInByte
             int cc = ccMapping->getIntAttribute("cc", -1);
             String target = ccMapping->getStringAttribute("target", "");
             if ( target.isNotEmpty() && cc != -1 ) {
+                if ((cc >> 8) == 0) {
+                    // Simple migration logic lets old mappings without channel
+                    // work on channel 1.
+                    cc |= 1 << 8;
+                }
                 for(int i=0;i<ctrl.size();i++) {
                     if ( ctrl[i]->label == target) {
                         TRACE("mapping CC=%d to %s", cc, target.toRawUTF8());

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -392,7 +392,7 @@ public :
         this->target = target;
         setMessage("Mapping: " + String(target->label) + ", waiting for midi controller change (CC) message...");
         addButton("CANCEL", -1);
-        editor->processor->lastCCUsed.setValue(-1);        
+        editor->processor->lastCCUsed.setValue(-1);
         editor->processor->lastCCUsed.addListener(this);
     }
     

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -403,16 +403,17 @@ void DexedAudioProcessor::processMidiMessage(const MidiMessage *msg) {
                     }
                     break;
                 default:
-                    TRACE("handle CC %d %d", ctrl, value);
-                    if ( mappedMidiCC.contains(ctrl) ) {
-                        Ctrl *linkedCtrl = mappedMidiCC[ctrl];
+                    TRACE("handle channel %d CC %d = %d", channel, ctrl, value);
+                    int channel_cc = (channel << 8) | ctrl;
+                    if ( mappedMidiCC.contains(channel_cc) ) {
+                        Ctrl *linkedCtrl = mappedMidiCC[channel_cc];
                         
                         // We are not publishing this in the DSP thread, moving that in the
                         // event thread
                         linkedCtrl->publishValueAsync((float) value / 127);
                     }
                     // this is used to notify the dialog that a CC value was received.
-                    lastCCUsed.setValue(ctrl);
+                    lastCCUsed.setValue(channel_cc);
                 }
             }
             return;


### PR DESCRIPTION
This change makes it possible to map the entire instrument with CC's from different channels (e.g. Channel 1 for Operator 1, Channel 2 for Operator 2, etc.). Without channel discrimination in the dexed mappings, there aren't enough CC #'s to go around. As a simple and efficient approach, the channel and CC share an int value (CC on bits 0-7, channel on bits 8-15).