### PR TITLE
Fix parameter remote control in Bitwig by using name as parameter ID

### DIFF
--- a/Source/PluginParam.cpp
+++ b/Source/PluginParam.cpp
@@ -331,6 +331,7 @@ float CtrlFloat::getValueHost() {
 }
 
 void CtrlFloat::setValueHost(float v) {
+    TRACE("float set idx=%d v=%f", idx, v);
     *vPointer = v;
 }
 
@@ -364,7 +365,7 @@ void CtrlDX::setValueHost(float f) {
 }
 
 void CtrlDX::setValue(int v) {
-    TRACE("setting value %d %d", dxOffset, v);
+    TRACE("setting value idx=%d dxOffset=%d v=%d", idx, dxOffset, v);
     dxValue = v;
     if (dxOffset >= 0) {
         if (parent != NULL)
@@ -628,7 +629,7 @@ void DexedAudioProcessor::setDxValue(int offset, int v) {
         packOpSwitch();
         v = data[155];
     } else if ( data[offset] != v ) {
-        TRACE("setting dx %d %d", offset, v);
+        TRACE("setting dx offset=%d v=%d", offset, v);
         data[offset] = v;
     } else {
         TRACE("ignoring dx7 same values %d %d", offset, v);
@@ -670,6 +671,7 @@ float DexedAudioProcessor::getParameter(int index) {
 }
 
 void DexedAudioProcessor::setParameter(int index, float newValue) {
+    TRACE("setParameter index=%d newValue=%f", index, newValue);
     forceRefreshUI = true;
     ctrl[index]->setValueHost(newValue);
 }
@@ -724,6 +726,10 @@ const String DexedAudioProcessor::getParameterName(int index) {
 
 const String DexedAudioProcessor::getParameterText(int index) {
     return ctrl[index]->getValueDisplay();
+}
+
+String DexedAudioProcessor::getParameterID(int index) {
+    return getParameterName(index);
 }
 
 void DexedAudioProcessor::loadPreference() {

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -208,6 +208,7 @@ public :
     void setParameter (int index, float newValue);
     const String getParameterName (int index);
     const String getParameterText (int index);
+    String getParameterID (int index) override;
 
     const String getInputChannelName (int channelIndex) const;
     const String getOutputChannelName (int channelIndex) const;


### PR DESCRIPTION
Bitwig Studio's remote control of Dexed was broken (as of version 4.2.2) such that Dexed parameters could be mapped to remote controls, but changing those remotes would not affect change in Dexed. This was apparently caused by parameter ID strings clashing with the default implementation which converts index int to String. Using the unique parameter name as the ID instead resolved the problem.

Before fix:
<details><summary>Plugin misbehaving output from Bitwig</summary>
<pre>
[2022-04-17 14:36:02.250 float-main-app error] Plugin misbehaving Dexed: Listed an automatable parameter as a MIDI parameter: ParamID = 1567 index = 10
[2022-04-17 14:36:02.251 float-main-app error] Plugin misbehaving Dexed: Multiple definitions of parameters with the same parameter id were found for the following parameter ids: 182418231822182118201819181818171816181517931792166516641663166216611660163416331791163217901631178916301788162917871572173015711729160715701728160615691727160317611604176215671725163816011759160515681726160217601573173115741575157616351598175616361599175716371600175816661667166816691691169216931694169516961697169816991700172217231724175317541755178417851786
</pre>
</details>

After fix: No "Plugin misbehaving" output from Bitwig, and remote controls work.