### PR TITLE
Flush denormals

### DIFF
--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -186,6 +186,9 @@ void DexedAudioProcessor::releaseResources() {
 }
 
 void DexedAudioProcessor::processBlock(AudioSampleBuffer& buffer, MidiBuffer& midiMessages) {
+
+    juce::ScopedNoDenormals noDenormals;
+
     int numSamples = buffer.getNumSamples();
     int i;
     


### PR DESCRIPTION
Dexed shows an increase in cpu usage on note off
calculating tiny numbers way below audible range.
This change sets these small numbers to zero.

should also help with https://github.com/asb2m10/dexed/issues/322#issuecomment-1097108930