### PR TITLE
Clap Implementation for DEXED

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,8 @@ products/
 .DS_Store
 build*/
 .cache/
+
+# CLION
+.idea
+cmake-build-*
+ignore/

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "libs/JUCE"]
 	path = libs/JUCE
 	url = https://github.com/juce-framework/JUCE.git
+[submodule "libs/clap-juce-extensions"]
+	path = libs/clap-juce-extensions
+	url = https://github.com/free-audio/clap-juce-extensions

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ project(Dexed VERSION 0.9.6)
 
 set(DEXED_JUCE_PATH "${CMAKE_SOURCE_DIR}/libs/JUCE" CACHE STRING "Path to JUCE library source tree")
 add_subdirectory(${DEXED_JUCE_PATH} ${CMAKE_BINARY_DIR}/JUCE EXCLUDE_FROM_ALL)
+add_subdirectory(libs/clap-juce-extensions EXCLUDE_FROM_ALL)
 
 #Compile commands, useful for some IDEs like VS-Code
 set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -18,6 +18,10 @@ juce_add_plugin("${BaseTargetName}"
         DESCRIPTION "Dexed FM Synth"
 )
 
+clap_juce_extensions_plugin(TARGET ${BaseTargetName}
+        CLAP_ID "com.digital-suburban.dexed"
+        CLAP_FEATURES instrument FM DX7)
+
 juce_generate_juce_header(${PROJECT_NAME})
 
 target_sources(${BaseTargetName} PRIVATE

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -791,6 +791,10 @@ AudioProcessorEditor* DexedAudioProcessor::createEditor() {
     // no display found, scaling to default value	
     if ( ! displayFound )
         dpiScaleFactor = 1.0;
+
+    // Currently the clap juce wrapper doesn't work with this deprecated scale factor direct set so
+    if ( is_clap )
+       dpiScaleFactor = 1.0;
     
     // The scale factor needs to be done after object creation otherwise Bitwig, Live and REAPER can't render the
     // plugin window.

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -23,6 +23,8 @@
 
 #include "../JuceLibraryCode/JuceHeader.h"
 
+#include "clap-juce-extensions/clap-juce-extensions.h"
+
 #include "msfa/controllers.h"
 #include "msfa/dx7note.h"
 #include "msfa/lfo.h"
@@ -60,7 +62,7 @@ enum DexedEngineResolution {
 //==============================================================================
 /**
 */
-class DexedAudioProcessor  : public AudioProcessor, public AsyncUpdater, public MidiInputCallback
+class DexedAudioProcessor  : public AudioProcessor, public AsyncUpdater, public MidiInputCallback, public clap_juce_extensions::clap_properties
 {
     static const int MAX_ACTIVE_NOTES = 16;
     ProcessorVoice voices[MAX_ACTIVE_NOTES];


### PR DESCRIPTION
This diff adds the necessary hooks to allow Dexed to
build as a CLAP 1.0.0 plugin. More information on the
new CLAP plugin format is at https://github.com/free-audio/clap

Due to Dexed using a slightly older scaling API, this also disables
the 1.5x high resolution monitor scaling feature in plugins just
for CLAP plugins only