### PR TITLE
SIMD-vectorize operators using libhwy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.16)
 project(Dexed VERSION 0.9.6)
 
+find_package(hwy REQUIRED)
+
 #Compile commands, useful for some IDEs like VS-Code
 set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
 

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -103,6 +103,7 @@ PRIVATE
     juce::juce_graphics
     juce::juce_gui_basics
     juce::juce_gui_extra
+    hwy::hwy
     surgesynthteam_tuningui
     tuning-library
     DexedResources

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -20,6 +20,7 @@
 
 #include <stdarg.h>
 #include <bitset>
+#include <cstring>
 
 #include <hwy/highway.h>
 #include <hwy/aligned_allocator.h>
@@ -246,10 +247,8 @@ void DexedAudioProcessor::processBlock(AudioSampleBuffer& buffer, MidiBuffer& mi
                 processMidiMessage(midiMsg);
             }
             
-            for (int j = 0; j < N; ++j) {
-                audiobuf[j] = 0;
-                sumbuf[j] = 0;
-            }
+            std::memset(audiobuf.get(), 0, sizeof(int32_t)*N);
+            std::memset(sumbuf.get(), 0, sizeof(float)*N);
             int32_t lfovalue = lfo.getsample();
             int32_t lfodelay = lfo.getdelay();
             


### PR DESCRIPTION
This is an offshoot from some experimentation I was doing using dexed and I wasn't really planning on developing further, but in case it's useful to anyone I'll present it here.

This uses google's [highway library](https://github.com/google/highway) to add SIMD versions of the most expensive parts of the synthesis. My crude testing suggests modest speed improvements of 10-20% for SSE2 to AVX2, but on an AVX512 machine this easily doubles speed for me. An ARM NEON system showed an embarrassing 4% acceleration.

Dexed doesn't have a test suite, but comparing the results against the existing scalar implementation showed a maximum relative error of ~0.003 between the two, which will be attributable to a different order of operations in some places.

I don't know whether you'd ever actually want to make dexed depend on libhwy, but this would probably take a bit more polish if you ever wanted to actually merge it - I've tested it only on a limited variety of machines/architectures, haven't included options to disable vectorization support, have only configured libhwy for single-dispatch (no single-binary, dynamic cpu-extension-detecting, but I don't imagine it would be too hard to set that up).

The feedback-based operator loops are way too hard to vectorize, so they are left alone.