### PR TITLE
Option to enable LTO

### DIFF
--- a/.github/workflows/project-pipeline.yml
+++ b/.github/workflows/project-pipeline.yml
@@ -29,6 +29,7 @@ jobs:
       run: |
         if [ "$GITHUB_REF_TYPE" == "tag" ]; then
             echo "BUILD_TYPE=Release" >> "$GITHUB_ENV"
+            echo "ENABLE_LTO=1" >> "$GITHUB_ENV"
             echo "BUILD_VERSION=${GITHUB_REF_NAME:1}" >> "$GITHUB_ENV"
         else
             echo "BUILD_TYPE=Debug" >> "$GITHUB_ENV"
@@ -39,7 +40,7 @@ jobs:
 
     - name: Build
       run: |
-        cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DCMAKE_CXX_FLAGS=-DDEXED_ID=${{ env.BUILD_VERSION }}
+        cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DCMAKE_CXX_FLAGS=-DDEXED_ID=${{ env.BUILD_VERSION }} -DENABLE_LTO=${{ env.ENABLE_LTO }}
         cmake --build ${{github.workspace}}/build --config ${{ env.BUILD_TYPE }}
 
     - name: Show

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,15 @@ project(Dexed VERSION 0.9.6)
 #Compile commands, useful for some IDEs like VS-Code
 set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
 
+include(CheckIPOSupported)
+check_ipo_supported(RESULT supported OUTPUT error)
+if (supported)
+    option(ENABLE_LTO "Enable LTO" OFF)
+    if (ENABLE_LTO)
+        set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
+    endif()
+endif()
+
 #Minimum MacOS target, set globally
 
 if (${CMAKE_SYSTEM_NAME} STREQUAL "iOS")


### PR DESCRIPTION
LTO allows to eliminate dead code sections.

Why this may be useful, clap example.
Release build:

```
~/src/dexed bloaty build/Source/Dexed_artefacts/CLAP/Dexed.clap 
    FILE SIZE        VM SIZE    
 --------------  -------------- 
  34.1%  6.96Mi   0.0%       0    .strtab
  30.5%  6.22Mi  54.0%  6.22Mi    .text
   9.7%  1.97Mi   0.0%       0    .symtab
   9.4%  1.91Mi  16.6%  1.91Mi    .eh_frame
   8.4%  1.72Mi  14.9%  1.72Mi    .rodata
   3.1%   655Ki   5.6%   655Ki    .rela.dyn
   2.3%   476Ki   4.0%   476Ki    .eh_frame_hdr
   1.5%   319Ki   2.7%   319Ki    .data.rel.ro
   0.5%   109Ki   0.9%   109Ki    .gcc_except_table
   0.0%       0   0.5%  62.6Ki    .bss
   0.2%  33.8Ki   0.3%  33.8Ki    .dynstr
   0.1%  16.8Ki   0.1%  16.8Ki    .dynsym
   0.1%  13.7Ki   0.1%  13.7Ki    .rela.plt
   0.0%  9.12Ki   0.1%  9.12Ki    .plt
   0.0%  6.76Ki   0.1%  6.76Ki    .data
   0.0%  4.59Ki   0.0%  4.59Ki    .got.plt
   0.0%  2.96Ki   0.0%  2.69Ki    [14 Others]
   0.0%  2.72Ki   0.0%       0    [Unmapped]
   0.0%  1.88Ki   0.0%       0    [ELF Section Headers]
   0.0%  1.55Ki   0.0%  1.55Ki    .gnu.hash
   0.0%  1.41Ki   0.0%  1.41Ki    .gnu.version
 100.0%  20.4Mi 100.0%  11.5Mi    TOTAL
```

Release build with LTO:

```
~/src/dexed bloaty build/Source/Dexed_artefacts/CLAP/Dexed.clap 
    FILE SIZE        VM SIZE    
 --------------  -------------- 
  47.0%  2.47Mi  56.6%  2.47Mi    .text
  19.9%  1.05Mi  24.0%  1.05Mi    .rodata
  12.5%   670Ki   0.0%       0    .strtab
   5.6%   299Ki   6.7%   299Ki    .eh_frame
   5.4%   292Ki   0.0%       0    .symtab
   5.1%   273Ki   6.1%   273Ki    .rela.dyn
   1.4%  77.9Ki   1.7%  77.9Ki    .data.rel.ro.local
   0.0%       0   1.3%  60.1Ki    .bss
   0.9%  49.5Ki   1.1%  49.5Ki    .eh_frame_hdr
   0.9%  47.5Ki   1.1%  47.5Ki    .gcc_except_table
   0.4%  21.1Ki   0.5%  21.1Ki    .data.rel.ro
   0.2%  9.97Ki   0.2%  9.97Ki    .dynstr
   0.2%  9.35Ki   0.2%  9.35Ki    .dynsym
   0.1%  7.15Ki   0.2%  7.15Ki    .rela.plt
   0.1%  4.78Ki   0.1%  4.78Ki    .plt
   0.1%  2.94Ki   0.1%  2.54Ki    [16 Others]
   0.1%  2.93Ki   0.1%  2.94Ki    .data
   0.0%  2.41Ki   0.1%  2.41Ki    .got.plt
   0.0%  2.06Ki   0.0%       0    [ELF Section Headers]
   0.0%  1.70Ki   0.0%       0    [Unmapped]
   0.0%     800   0.0%     800    .gnu.version
 100.0%  5.25Mi 100.0%  4.37Mi    TOTAL

```