### PR TITLE
implement dB-based VUMeters and a tricolor main VUMeter

### DIFF
--- a/Source/DXComponents.h
+++ b/Source/DXComponents.h
@@ -41,10 +41,71 @@ public:
     void paint(Graphics &g);
 };
 
+/*
 class VuMeter: public Component {
     void paint(Graphics &g);
 public : 
     float v;
+};
+*/
+
+class VuMeter : public juce::Component {
+public:
+    void paint(juce::Graphics& g);
+
+    // image of the stripe
+    juce::Image myStrip;
+
+    // width of the image
+    int width = 0;
+
+    // height of the original image,
+    // containing a dark and a bright stripes
+    int height = 0;
+
+    // height of a single stripe (half of the height of the original stripe)
+    int height2 = 0;
+
+    // total number of blocks ("LED"s) of the stripe
+    static const int totalBlocks = 46;
+
+    // dimensions of a single block in pixels, for the case of the 140x80 sized image
+    static const int blockWidth = 2;
+    static const int blockGap = 1;
+    /*
+        // dimension of a single block in pixels, for the case of the 280x16 sized image
+        static const int blockWidth = 2*2;
+        static const int blockGap = 1*2;
+    */
+
+    // dimension of the border
+    static const int border = 1;
+    // dimension of a block plus the size of a gap between two adjacent blocks
+    static const int blockWidthWithGap = blockWidth + blockGap;
+
+    // number of block having different colors 
+    static const int numRedBlocks = 6;
+    static const int numYellowBlocks = 6;
+    static const int numGreenBlocks = totalBlocks - numRedBlocks - numYellowBlocks;
+
+    // array of images of the individual stripes
+    static const int numStripes = totalBlocks + 1;
+    juce::Image stripes[numStripes];
+
+	VuMeter(bool tricolor, int maxdB2);
+
+    float v = 0.0F;
+
+    // minimum dB associated to leftmost LED, for solid stripe
+    int mindB = -39;
+    // minimum amplitude equivalent to mindB, for solid stripe
+    float minamp = (float)pow(10.0, mindB * 0.1);
+    // maximum amplitude, for solid stripe
+    float maxamp = 1.0F;
+
+    void recolorize();
+    void createStripes();
+    float dB_to_amp(float dB);
 };
 
 class LcdDisplay : public Component {

--- a/Source/GlobalEditor.cpp
+++ b/Source/GlobalEditor.cpp
@@ -324,7 +324,7 @@ GlobalEditor::GlobalEditor ()
 
     output->setBounds (157, 60, 34, 34);
 
-    vuOutput.reset (new VuMeter());
+    vuOutput.reset (new VuMeter(true, 6));
     addAndMakeVisible (vuOutput.get());
     vuOutput->setName ("vuOutput");
 

--- a/Source/OperatorEditor.cpp
+++ b/Source/OperatorEditor.cpp
@@ -236,7 +236,7 @@ OperatorEditor::OperatorEditor ()
 
     ampModSens->setBounds (140, 76, 34, 34);
 
-    vu.reset (new VuMeter());
+    vu.reset (new VuMeter(false, 0));
     addAndMakeVisible (vu.get());
     vu->setName ("vu");
 

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -245,7 +245,17 @@ void DexedAudioProcessorEditor::timerCallback() {
         return;
 
     for(int i=0;i<6;i++) {
-        operators[i].updateGain(sqrt(processor->voiceStatus.amp[5 - i]) / 8196);        // TODO: FUGLY !!!! change this sqrt nonsense
+        //operators[i].updateGain(sqrt(processor->voiceStatus.amp[5 - i]) / 8196);        // TODO: FUGLY !!!! change this sqrt nonsense
+
+        const int amp_min = 1036152;
+        const float one_per_amp_diff = (float)(1.0 / (259037922 - amp_min));
+        // These two constants were determined from the results produced by the OPL engine,
+        // because its minimum is smaller, its maximum is higher than in the other cases. 
+
+        int amp = processor->voiceStatus.amp[5 - i] - amp_min;
+        if (amp <= 0) amp = 0; 
+        operators[i].updateGain(amp * one_per_amp_diff);
+
         operators[i].updateEnvPos(processor->voiceStatus.ampStep[5 - i]);
     }
     global.updatePitchPos(processor->voiceStatus.pitchStep);

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -290,10 +290,11 @@ void DexedAudioProcessor::processBlock(AudioSampleBuffer& buffer, MidiBuffer& mi
     for(i=0; i<numSamples; i++) {
         float s = std::abs(channelData[i]);
         
-        const double decayFactor = 0.99992;
+        //const double decayFactor = 0.99992;
+        const float decayFactor = 0.9997F;
         if (s > vuSignal)
             vuSignal = s;
-        else if (vuSignal > 0.001f)
+        else if (vuSignal > 1.26E-4F) // -39 dB, the min amplitude associated to leftmost LED
             vuSignal *= decayFactor;
         else
             vuSignal = 0;


### PR DESCRIPTION
Dear Pascal,

Please apply my current pull request. It implements dB-based VU meters and a tricolor stripe for the main VU meter. In addition, the following improvement has been introduced:
- for a VU meter, during initialization, 47 single LED stripe images are created and stored in an array. The 0th element of this array shows all LEDs in dark color, the 1st element shows the leftmost LED in bright color, the 2nd element shows the two leftmost LEDs in bright color, and so on, until the 46th element, which contains all LEDs in bright.
- in the ``VuMeter::paint()`` method, there were previously two calls to the ``drawImage()`` method: the first one redrew the entire LED stripe in dark, and the second one redrew the necessary leftmost LEDs in bright color. Now, there is a single call to the ``drawImageAt()`` method, which refers to the proper element of the array of images mentioned above, indexed by the dB-based scaling. (And, it is also hoped, the method ``drawImageAt()`` is faster on its own than the ``drawImage()``).