### PR TITLE
implement faster dB-based VUMeters and a tricolor main VUMeter

### DIFF
--- a/Dexed.jucer
+++ b/Dexed.jucer
@@ -75,6 +75,8 @@
         <FILE id="TF7JMc" name="EngineOpl.h" compile="0" resource="0" file="Source/EngineOpl.h"/>
       </GROUP>
       <GROUP id="{998D2187-B355-9C12-0FB2-2D048B83342D}" name="ui">
+        <FILE id="lQfZ4Z" name="VUMeter.cpp" compile="1" resource="0" file="Source/VUMeter.cpp"/>
+        <FILE id="ZXsxxH" name="VUMeter.h" compile="0" resource="0" file="Source/VUMeter.h"/>
         <FILE id="Ec211k" name="PluginEditor.cpp" compile="1" resource="0"
               file="Source/PluginEditor.cpp"/>
         <FILE id="lZFsG0" name="PluginEditor.h" compile="0" resource="0" file="Source/PluginEditor.h"/>

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -56,6 +56,7 @@ target_sources(${BaseTargetName} PRIVATE
 	ProgramListBox.cpp
 	SysexComm.cpp
 	TuningShow.cpp
+	VUMeter.cpp
         msfa/dx7note.cc
         msfa/env.cc
         msfa/exp2.cc

--- a/Source/DXComponents.cpp
+++ b/Source/DXComponents.cpp
@@ -315,7 +315,7 @@ void PitchEnvDisplay::paint(Graphics &g) {
     g.setColour(Colours::white);
     g.fillEllipse(dx-2, dy-2, 4, 4);
 }
-
+/*
 void VuMeter::paint(Graphics &g) {
     Image myStrip = ImageCache::getFromMemory(BinaryData::Meter_140x8_png, BinaryData::Meter_140x8_pngSize);
     
@@ -333,7 +333,7 @@ void VuMeter::paint(Graphics &g) {
     
     g.drawImage(myStrip, 0, 0, brkpoint, 8, 0, 8, brkpoint, 8);
 }
-
+*/
 LcdDisplay::LcdDisplay() {
     paramMsg = "DEXED " DEXED_VERSION;
 }

--- a/Source/DXComponents.h
+++ b/Source/DXComponents.h
@@ -40,13 +40,13 @@ public:
     char vPos;
     void paint(Graphics &g);
 };
-
+/*
 class VuMeter: public Component {
     void paint(Graphics &g);
 public : 
     float v;
 };
-
+*/
 class LcdDisplay : public Component {
 public:
     LcdDisplay();

--- a/Source/GlobalEditor.cpp
+++ b/Source/GlobalEditor.cpp
@@ -324,7 +324,9 @@ GlobalEditor::GlobalEditor ()
 
     output->setBounds (157, 60, 34, 34);
 
-    vuOutput.reset (new VuMeter());
+    //vuOutput.reset (new VuMeter());
+    //vuOutput.reset(new VuMeterMain(6));
+    vuOutput.reset(new VuMeterOutput);
     addAndMakeVisible (vuOutput.get());
     vuOutput->setName ("vuOutput");
 
@@ -876,7 +878,7 @@ BEGIN_JUCER_METADATA
           int="0.0" style="RotaryVerticalDrag" textBoxPos="NoTextBox" textBoxEditable="0"
           textBoxWidth="80" textBoxHeight="20" skewFactor="1.0" needsCallback="1"/>
   <GENERICCOMPONENT name="vuOutput" id="dac75af912267f51" memberName="vuOutput" virtualName=""
-                    explicitFocusOrder="0" pos="6 103 140 8" class="VuMeter" params=""/>
+                    explicitFocusOrder="0" pos="6 103 140 8" class="VuMeterOutput" params=""/>
   <TEXTBUTTON name="initButton" id="92b278163c42e21d" memberName="initButton"
               virtualName="" explicitFocusOrder="0" pos="100 111 50 30" buttonText="INIT"
               connectedEdges="0" needsCallback="1" radioGroupId="0"/>

--- a/Source/GlobalEditor.h
+++ b/Source/GlobalEditor.h
@@ -105,7 +105,7 @@ private:
     std::unique_ptr<juce::Slider> algo;
     std::unique_ptr<LcdDisplay> lcdDisplay;
     std::unique_ptr<juce::Slider> output;
-    std::unique_ptr<VuMeter> vuOutput;
+    std::unique_ptr<VuMeterOutput> vuOutput;
     std::unique_ptr<juce::TextButton> initButton;
     std::unique_ptr<juce::TextButton> parmButton;
     std::unique_ptr<juce::TextButton> cartButton;

--- a/Source/OperatorEditor.cpp
+++ b/Source/OperatorEditor.cpp
@@ -19,7 +19,7 @@
 
 //[Headers] You can add your own extra header files here...
 //[/Headers]
-
+#include "VUMeter.h"
 #include "OperatorEditor.h"
 
 

--- a/Source/OperatorEditor.h
+++ b/Source/OperatorEditor.h
@@ -24,6 +24,7 @@
 #include "PluginProcessor.h"
 #include "DXComponents.h"
 #include "DXLookNFeel.h"
+#include "VUMeter.h"
 //[/Headers]
 
 

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -245,7 +245,19 @@ void DexedAudioProcessorEditor::timerCallback() {
         return;
 
     for(int i=0;i<6;i++) {
-        operators[i].updateGain(sqrt(processor->voiceStatus.amp[5 - i]) / 8196);        // TODO: FUGLY !!!! change this sqrt nonsense
+        //operators[i].updateGain(sqrt(processor->voiceStatus.amp[5 - i]) / 8196);        // TODO: FUGLY !!!! change this sqrt nonsense
+
+        const int amp_min = 1036152;
+        const float one_per_amp_diff = (float)(1.0 / (259037922 - amp_min));
+        // Note, that minimum and maximum values of ``amp`` are different and depend on the engines. 
+        // These two constants were determined from the results produced by the OPL engine,
+        // because its minimum is smaller, its maximum is higher than in the other cases. 
+
+        int amp = processor->voiceStatus.amp[5 - i] - amp_min;
+        if (amp <= 0) amp = 0;
+        operators[i].updateGain(amp * one_per_amp_diff);
+
+
         operators[i].updateEnvPos(processor->voiceStatus.ampStep[5 - i]);
     }
     global.updatePitchPos(processor->voiceStatus.pitchStep);

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -151,6 +151,7 @@ public :
     
     bool forceRefreshUI;
     float vuSignal;
+    double vuDecayFactor = 0.999361; // (for 48 kHz sampling rate)
     bool showKeyboard;
     int getEngineType();
     void setEngineType(int rs);

--- a/Source/VUMeter.cpp
+++ b/Source/VUMeter.cpp
@@ -1,0 +1,377 @@
+/*
+  ==============================================================================
+
+    VUMeter.cpp
+    Created: 29 Jun 2024 1:03:22pm
+    Author:  Fulop Nandor
+
+  ==============================================================================
+*/
+
+#include <JuceHeader.h>
+
+#include "VUMeter.h"
+
+// Constructor: sets the index calculating function
+// according to the determined endianess.
+VuMeterBase::VuMeterBase(int maxdB) {
+    mindB = maxdB - totalBlocks + 1;
+
+    u_fip_t u;
+
+    // a "magic float number"; in a Little Endian System, 
+    // the values of its individual bytes are, in order:
+    // 0x20 (LSB), 0x10, 0x08 and 0x40 (MSB).
+    u.f = 2.125984191894531e+00F;
+
+    if (u.b4[3] == 0x40 && u.b4[2] == 0x08) {
+        // a Little Endian system identified;
+        // set log-free faster index calculationg function
+        ampToStripeIndex = &VuMeterBase::ampToStripeIndex_le;
+        indexBiasMindB2 = ampTodB21_le(dB2ToAmp((float)mindB));
+DBG("VuMeterBase::VuMeterBase(): Little Endian Float System identified");
+    }
+    else if (u.b4[0] == 0x40 && u.b4[1] == 0x08) {
+        // a Big Endian system identified
+        // set log-free faster index calculationg function
+        ampToStripeIndex = &VuMeterBase::ampToStripeIndex_be;
+        indexBiasMindB2 = ampTodB21_be(dB2ToAmp((float)mindB));
+DBG("VuMeterBase::VuMeterBase(): Big Endian Float System identified");
+    }
+    else {
+        // the endianess of floats is not identified;
+        // fall back to function using the slower ``log()``
+        ampToStripeIndex = &VuMeterBase::ampToStripeIndex_log;
+        minamp = dB10ToAmp((float)mindB);
+        maxamp = dB10ToAmp((float)maxdB);
+DBG("VuMeterBase::VuMeterBase(): Unidentified Endian Float System");
+    }
+}
+
+// Calculates the index to be used to address array of images of stripes
+// based on the exact decibel values (calls to ``log()``).
+int VuMeterBase::ampToStripeIndex_log(float amp) {
+    int index;
+
+    amp = fabs(amp);
+
+    // check amplitude, whether it is out of the range
+    if (amp <= minamp) {
+        index = 0;
+    }
+    else if (amp >= maxamp) {
+        index = totalBlocks;
+    }
+    else {
+        // index = (int) (10.0F * log10(amp)) - mindB;
+        // Note: in some systems, the execution of ``log()`` is faster than ``log10()``,
+        // while ``log10`` was never experienced faster than ``log()``  
+        index = (int)(tenPerLog10 * log(amp)) - mindB;
+
+        // against the perpetual paranoia related to rounding and /under/overflow of floats
+        // (in principle, the following conditions should never be met... however, "the devil never sleeps").
+        if (index < 0) index = 0;
+        if (index > totalBlocks) index = totalBlocks;
+    }
+
+    return index;
+};
+
+// Calculates the approximating dB21 value
+// in case of Little Endian Float Systems.
+inline int VuMeterBase::ampTodB21_le(float amp) {
+    // room for the float-int punning
+    u_fip_t u_amp;
+
+    // store the float amplitude value for the float-int punning
+    u_amp.f = amp;
+
+    // shift bits of exponent and mantissa to by boundaries,
+    // throwing sign bit away
+    u_amp.n <<= 1;
+
+    // get value of the exponent multiplied by 3 
+    // and increase it by 0, 1 or 2, depending on MSB of the mantissa
+    return u_amp.bLE.e + u_amp.bLE.e + u_amp.bLE.e + mlut[u_amp.bLE.m2];
+}
+
+// Calculates the index to be used to address array of images of stripes
+// based on the approximating dB21 values
+// in case of Little Endian Float Systems.
+int VuMeterBase::ampToStripeIndex_le(float amp) {
+    int index = ampTodB21_le(amp)  - indexBiasMindB2;
+
+    if (index < 0)
+        index = 0;
+    else if (index > totalBlocks)
+        index = totalBlocks;
+
+    return index;
+}
+
+// Calculates the approximating dB21 value
+// in case of Big Endian Float Systems.
+inline int VuMeterBase::ampTodB21_be(float amp) {
+    // room for the float-int punning
+    u_fip_t u_amp;
+
+    // store the float amplitude value for the float-int punning
+    u_amp.f = amp;
+
+    // shift bits of exponent and mantissa to byte boundaries,
+    // throwing sign bit away
+    u_amp.n <<= 1;
+
+    // get value of the exponent multiplied by 3 
+    // and increase it by 0, 1 or 2, depending on MSB of the mantissa
+    return u_amp.bBE.e + u_amp.bBE.e + u_amp.bBE.e + mlut[u_amp.bBE.m2];
+}
+
+// Calculates the index to be used to address array of images of stripes
+// based on the approximating dB21 values
+// in case of Big Endian Float Systems.
+int VuMeterBase::ampToStripeIndex_be(float amp) {
+    int index = ampTodB21_be(amp) - indexBiasMindB2;
+
+    if (index < 0)
+        index = 0;
+    else if (index > totalBlocks)
+        index = totalBlocks;
+
+    return index;
+}
+
+// Paints a single stripe.
+void VuMeterBase::paint(Graphics& g) {
+    int index = (this->*ampToStripeIndex)(v);
+    g.drawImageAt(*(singleStripes[index]), 0, 0); // it might be more efficient than the ``drawImage()``
+}
+
+// Calculates amplitude value from the traditional decibel (based on log10),
+// supposing that reference amplitude is the unity (i.e 1.0F).
+float VuMeterBase::dB10ToAmp(float dB10) {
+    return (float)pow(10.0, ((double)dB10 * 0.1));
+}
+
+// Calculates amplitude value from the approximating log2-based decibel,
+// supposing that reference amplitude is the unity (i.e 1.0F).
+float VuMeterBase::dB2ToAmp(float dB2) {
+    return (float)pow(2.0, ((double)dB2 / 3.0));
+}
+
+// Look up table for mantissa; it is filled by:
+// - 0 for elements 0...65,
+// - 1 for elements 66..149,
+// - 2 for elements 150..255.
+// Hint: 66 and 150 is the value of MSB of the mantissa
+// of float values of the power of 2.0F up to 1/3 and 2/3,
+// in the 4-byte IEEE 754 float representations.
+const uint8_t VuMeterBase::mlut[256] = {
+    // 0  1  2  3  4  5  6  7  8  9 
+       0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  // 00
+       0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  // 10
+       0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  // 20
+       0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  // 30
+       0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  // 40
+       0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  // 50
+       0, 0, 0, 0, 0, 0, 1, 1, 1, 1,  // 60
+       1, 1, 1, 1, 1, 1, 1, 1, 1, 1,  // 70
+       1, 1, 1, 1, 1, 1, 1, 1, 1, 1,  // 80
+       1, 1, 1, 1, 1, 1, 1, 1, 1, 1,  // 90
+
+       1, 1, 1, 1, 1, 1, 1, 1, 1, 1,  // 100
+       1, 1, 1, 1, 1, 1, 1, 1, 1, 1,  // 110
+       1, 1, 1, 1, 1, 1, 1, 1, 1, 1,  // 120
+       1, 1, 1, 1, 1, 1, 1, 1, 1, 1,  // 130
+       1, 1, 1, 1, 1, 1, 1, 1, 1, 1,  // 140
+       2, 2, 2, 2, 2, 2, 2, 2, 2, 2,  // 150
+       2, 2, 2, 2, 2, 2, 2, 2, 2, 2,  // 160
+       2, 2, 2, 2, 2, 2, 2, 2, 2, 2,  // 170
+       2, 2, 2, 2, 2, 2, 2, 2, 2, 2,  // 180
+       2, 2, 2, 2, 2, 2, 2, 2, 2, 2,  // 190
+
+       2, 2, 2, 2, 2, 2, 2, 2, 2, 2,  // 200
+       2, 2, 2, 2, 2, 2, 2, 2, 2, 2,  // 210
+       2, 2, 2, 2, 2, 2, 2, 2, 2, 2,  // 220
+       2, 2, 2, 2, 2, 2, 2, 2, 2, 2,  // 230
+       2, 2, 2, 2, 2, 2, 2, 2, 2, 2,  // 240
+       2, 2, 2, 2, 2, 2               // 250
+};
+
+VuMeterBase::~VuMeterBase() {
+    // intentionally blank (for testing only)
+}
+
+VuStripesSingleton::~VuStripesSingleton() {
+    // release memblks reserved for images of solid stripes
+    destroyStripes(tricolorVuMeterStripes);
+    // release memblks reserved for images of tricolor stripes
+    destroyStripes(solidVuMeterStripes);
+DBG("VuStripesSingleton::~VuStripesSingleton() called");
+}
+
+VuStripesSingleton::VuStripesSingleton() {
+    // create solid color single stripes
+    createStripes(solidVuMeterStripes, false);
+    // create tricolor single stripes
+    createStripes(tricolorVuMeterStripes, true);
+DBG("VuStripesSingleton::VuStripesSingleton() called");
+}
+
+
+void VuStripesSingleton::createStripes(juce::Image** array, bool tricolor) {
+    // get a copy of the original image, having two bands
+    juce::Image origDoubleStripe = ImageCache::getFromMemory(BinaryData::Meter_140x8_png, BinaryData::Meter_140x8_pngSize).createCopy();
+
+    if (origDoubleStripe.isValid()) {
+        // get dimensions of the image
+        int height = origDoubleStripe.getHeight();
+        int height2 = height / 2;
+        int width = origDoubleStripe.getWidth();
+
+        // create a tricolor image if specified
+        if (tricolor) {
+            uint8_t a; // alfa
+            uint8_t r; // red
+            uint8_t g; // green
+            uint8_t b; // blue
+
+            int iFirstRedBlock = VuMeterBase::totalBlocks - VuMeterOutput::numRedBlocks;
+            int xFirstRedBlock = iFirstRedBlock * VuMeterBase::blockWidthWithGap + VuMeterBase::blockGap + VuMeterBase::border;
+            int xFirstYellowBlock = (iFirstRedBlock - VuMeterOutput::numYellowBlocks) * VuMeterBase::blockWidthWithGap + VuMeterBase::blockGap + VuMeterBase::border;
+
+            // repaint
+            for (int x = 0; x < width; ++x) {
+                for (int y = 0; y < height; ++y) {
+                    // get color of the given pixel
+                    juce::Colour pixel = origDoubleStripe.getPixelAt(x, y);
+
+                    // get the components of the current color
+                    uint32_t rgba = pixel.getARGB();
+                    a = (uint8_t)((rgba & 0xFF000000) >> 24);
+                    r = (uint8_t)((rgba & 0x00FF0000) >> 16);
+                    g = (uint8_t)((rgba & 0x0000FF00) >> 8);
+                    b = (uint8_t)(rgba & 0x000000FF);
+
+                    // create new colors
+                    if (x >= xFirstRedBlock) {
+                        // leave red blocks as are
+                    }
+                    else if (x >= xFirstYellowBlock) {
+                        // make yellow blocks: set blue component to 0, and green and red ones to their max
+                        b = 0;
+                        r = g = r > g ? r : b;
+                    }
+                    else {
+                        // make green blocks: swap the original red and green components
+                        uint8_t t = r; r = g; g = t;
+                    }
+                    juce::Colour newpixel = juce::Colour::fromRGBA(r, g, b, a);
+
+                    // set it
+                    origDoubleStripe.setPixelAt(x, y, newpixel);
+                }
+            }
+        }
+
+// TODO: these two methods below should be tested, which one is the faster 
+#ifdef CREATE_STRIPES_PIXEL_BY_PIXEL
+
+        // create individual stripes - via the simplest, a pixel-by-pixel setting method
+         
+        // the boundary between the bright and dark LEDs is determined by xLimit;
+        // the ``iStripe``-th stripe has number of ``iStripe`` bright LEDs
+        for (int iStripe = 0, xLimit = VuMeterBase::blockGap + VuMeterBase::border; iStripe <= VuMeterBase::totalBlocks; ++iStripe, xLimit += VuMeterBase::blockWidthWithGap) {
+            // create an RGB-based single stripe
+            juce::Image* img = new juce::Image(juce::Image::RGB, width, height2, false);
+
+            // set the iStripe pieces of the leftmost LEDs to a bright color,
+            // leave the remaining rightmost LEDs in dark color
+            for (int x = 0; x < width; ++x) {
+                for (int y = 0; y < height2; ++y) {
+                    juce::Colour pixel;
+                    if (x < xLimit) {
+                        // get a bright pixel from the lower bright band
+                        pixel = origDoubleStripe.getPixelAt(x, y + height2);
+                    }
+                    else {
+                        // get a dark pixel from the upper dark band
+                        pixel = origDoubleStripe.getPixelAt(x, y);
+                    }
+                    // set the pixel of the current stripe
+                    img->setPixelAt(x, y, pixel);
+                }
+            }
+
+            array[iStripe] = img;
+        }
+
+#else //CREATE_STRIPES_PIXEL_BY_PIXEL
+
+        // create individual stripes - via JUCE's image manipulation methods
+
+        // create a single, RGB colors based, opaque, dark stripe
+        juce::Image* img = new juce::Image(juce::Image::RGB, width, height2, false);
+        juce::Graphics gimg(*img);
+        juce::Rectangle upperStripeRectangle(0, 0, width, height2);
+        juce::Image upperStripe = origDoubleStripe.getClippedImage(upperStripeRectangle);
+        gimg.drawImageAt(upperStripe, 0, 0, false);
+        array[0] = img;
+
+        // create individual stripes having 1, 2, ... bright LEDs;
+        // the ``iStripe``-th stripe has number of ``iStripe`` bright LEDs
+        int xStart = VuMeterBase::blockGap + VuMeterBase::border;         // left edge of new bright LED
+        for (int iStripe = 1; iStripe <= VuMeterBase::totalBlocks; ++iStripe) {
+            // get a copy of the previous single stripe,
+            // having one bright LED less then needed
+            juce::Image* imgCurrent = new juce::Image(img->createCopy());
+
+            // get a bright LED at the ``iStripe``-th position from the lower stripe
+            juce::Rectangle brightLEDRectangle(xStart, height2, VuMeterBase::blockWidthWithGap, height2);
+            juce::Image brightLED = origDoubleStripe.getClippedImage(brightLEDRectangle);
+
+            // draw a single bright LED only at ``iStripe``-th position on the current single stripe
+            juce::Graphics gimgCurrent(*imgCurrent);
+            gimgCurrent.drawImageAt(brightLED, xStart, 0, false);
+
+            // store this stripe having number of ÿÿiStripe`` bright LEDs
+            array[iStripe] = imgCurrent;
+
+            // use this image as source in the next loop
+            img = imgCurrent;
+
+            // advance the left edge for the next bright LED
+            xStart += VuMeterBase::blockWidthWithGap;
+        }
+
+#endif //CREATE_STRIPES_PIXEL_BY_PIXEL
+
+    }
+}
+
+void VuStripesSingleton::destroyStripes(juce::Image** array) {
+    for (int iStripe = numStripes - 1; iStripe >= 0; --iStripe) {
+        if (array[iStripe] != nullptr) {
+            delete array[iStripe];
+        }
+    }
+}
+
+// Constructor of VuMeter (solid color), using 0 dB as upper limit
+VuMeter::VuMeter(): VuMeterBase(0) {
+    singleStripes = VuStripesSingleton::getInstance().getSolidVuMeterStripes();
+}
+
+// Constructor of VuMeterOutput (tricolor), using +6 dB as upper limit
+VuMeterOutput::VuMeterOutput() : VuMeterBase(6) {
+    singleStripes = VuStripesSingleton::getInstance().getTricolorVuMeterStripes();
+}
+
+double VuMeterOutput::getDecayFactor(double sampleRate) {
+    constexpr double dBdrop = -40.0;    // a range of amplitude drop in dB
+    constexpr double fallingTime = 0.3; // falling time in seconds for the amplitude drop
+
+    return (float) exp(dBdrop / 10.0 * log(10.0) / (fallingTime * sampleRate));
+}
+
+//EOF

--- a/Source/VUMeter.h
+++ b/Source/VUMeter.h
@@ -1,0 +1,276 @@
+/*
+  ==============================================================================
+
+    VUMeter.h
+    Created: 29 Jun 2024 1:02:58pm
+    Author:  Fulop Nandor
+
+    
+    Summary
+    -------
+
+    The class ``VuMeter`` is instantiated as solid-colored logarithmic level 
+    indicators for the FM-operators  in ``OperatorEditor.cpp``, and the class 
+    ``VuMeterOutput`` is instantiated as a tricolor VU meter (more precisely: 
+    as a  logarithmic peak indicator with a leaky-integrator with about 300 
+    ms falling time for -40 dB changes) for output level in ``GlobalEditor.cpp``.
+    Both of them are derived from ``VuMeterBase`` class.
+    Inside the ``paint()`` method of ``VuMeterBase`` class,  an ``index`` value 
+    is calculated, based on an approximating decibel value of the proper 
+    amplutude. When called, the ``paint()`` method draws a single stripe that
+    contains exactly as many bright LEDs  as the value of the ``index`` variable.
+    A solid-colored set and a tricolor set of images of LED-stripes, each 
+    containing 0, 1, 2, ... etc. bright LEDs are created only once by the 
+    ``VuStripesSingleton`` from image file ``Meter_140x8.png`` 
+    containing a dark and a bright solid-color LED-stripes.
+   
+
+    Notes on a Quick Approximating Decibel Calculation
+    --------------------------------------------------
+
+    The use of any kind of float/double logarithm functions could be avoided
+    for the dB-calculations by a substituion with a few integer operations 
+    ("float-to-int punning"), if we satisfied with an appoximating dB-value 
+    instead of the exact one, based on the following tricks:
+    (1) The definition of the exact dB values related to the amplitude (not 
+    the power!) is:
+        dB = 10 * log10(amplitude);
+    (2) Let us define the 2-based dB (hereinafter denoted as ``dB2``) by 
+    replacing the ten-based ``log10()`` function by the two-base ``log2()`` 
+    function, utilizing the fact that log10(2) is approximately 0.3010...:
+        dB2 = 3 * log2(amplitude);
+    (3) In the 4-byte sized floats, according to IEEE 754 standard, there 
+    are 3 parts:
+        1 bit for the sign
+        8 bits for the 2-based exponent (biased by 127, see in case of the 
+        value 1.0F)
+        23 bits for the normalized mantissa (with a hidden 24th bit equals 
+        to 1, by the definition).
+    (4) Notice that if we are accepting of a 3 dB precision VU meter, this 
+    exponent (disregarding its bias) provides an approximation of the decibel 
+    values in the two-based logarithmic scale. So, let us introduce the 
+    examination of mantissa parts to get 1 dB precision approximating decibel 
+    value, defining the 1-dB-precision approximating decibel quantity, 
+    ``dB21``, as follows:
+        dB21 = 3 * exponent;
+        if (msb_of_mantissa >= 66) {
+            ++db21;
+        if (msb_of_manstissa >= 150)
+            ++dB21;
+        }
+    Here the 66 and the 150 are the decimal values of most significant 
+    bytes of the mantissa parts in the normalized float values of the 
+    2 to the power of 1/3 and 2/3, respectively, for the case of the 
+    4-byte sized IEEE 754 floats.
+    So the difference between two ``dB21`` values, calculated from a 
+    reference amplitude and the actual amplitude, provides the approximating 
+    value in a two-based logarithmic scale that can be interpreted as decibels. 
+    The idea above is originated from comment of User Gwirk, see at:
+    https://www.reddit.com/r/DSP/comments/65up2e/cheap_algorithm_for_vu_meter/?rdt=56174
+    
+    For the sake of the faster execution time,
+    a) the multiplication by 3 is replaced by additions, and
+    b) the nested if statements are replaced by a reading out from 
+    look-up-table:
+        db21 = exponent + exponent + exponent + mlut[msb_mantissa]
+    where the elements 0...65 of ``mlut[]`` are filled by 0s,
+    elements 66...149 are filled by 1s, and the elements 150...255 are 
+    filled by 2s.
+
+    This methods are implemented in member functions ``ampTodB21_*`` 
+    of ``VuMeterBase`` class. Because the byte order itself of IEEE 754 float 
+    values are not defined in the standard, the endianess of floats are 
+    determined in the constuctor of ``VuMeterBase`` during runtime. 
+    If the determination of the endianess failed, the usual float ``log()`` 
+    function, otherwise the proper float-to-int-punning method above is 
+    used. The float-to-int-punning based decibel calculation methods showed 
+    30% faster execution than calculation based on calls to ``log()`` 
+    function, in the following cases of CPUs:
+    - Intel(R) Core(TM) i5-4460 @ 3.20GHz (MS Windows 10; MS Visual Studio 2022 Community)
+    - Broadcom BCM2711 (Raspbian OS bookworm 64-bit; g++ Debian 12.2.0-14)
+    according to the tests performed by Google Benchmark (https://github.com/google/benchmark)
+  ==============================================================================
+*/
+
+#pragma once
+
+#include "JuceHeader.h"
+
+// defintion of some structs and a union used for the float-to-int punning
+#pragma pack(push)
+#pragma pack(1)
+typedef uint8_t b4_t[sizeof(float)];
+typedef struct {// struct of individual bytes of an IEEE 754 float in Little Endian Float Systems
+    uint8_t m0;
+    uint8_t m1;
+    uint8_t m2; // LS bit of exponent and 7 MS bits of the mantissa
+    uint8_t e;  // exponent and sign
+} b4LE_t;
+typedef struct {// struct of individual bytes of an IEEE 754 float in Big Endian Float Systems
+    uint8_t e;  // exponent
+    uint8_t m2; // LS bit of the exponent and 7 MS bits of the mantisse
+    uint8_t m1;
+    uint8_t m0;
+} b4BE_t;
+typedef union {
+    float f;    // access as a float
+    uint32_t n; // access as a 32-bit unsigned integer
+    b4_t b4;    // access as a 4 element byte array
+    b4LE_t bLE; 
+    b4BE_t bBE;
+} u_fip_t;
+#pragma pack(pop)
+
+
+// Fundamental class to define VU Meters.
+// Not intended to instantiate directly.
+class VuMeterBase : public Component {
+    // Paints an image of a single stripe addresses by the
+    // index calculated by the index calculating method
+    // set by its constructor.
+    // (The pointers of the images of the single stripes 
+    // to be drawn are stored in an array initialized by the 
+    // ``VuStripesSingleton``, which is created from
+    // the derived classes ``VuMeter`` and ``VuMeterOutput``.)
+    void paint(Graphics& g);
+
+    // the log()-function based stripe index calculator function
+    int ampToStripeIndex_log(float amp);
+
+    // the dB21 based decibel and stripe index calculator functions,
+    // for Little Endian Float Systems
+    inline int ampTodB21_le(float amp);
+    int ampToStripeIndex_le(float amp);
+
+    // the dB21 based decibel and stripe index calculator functions,
+    // for Big Endian Float Systems
+    inline int ampTodB21_be(float amp);
+    int ampToStripeIndex_be(float amp);
+
+public: 
+
+    // additional parameters characterizing the original double-stripe image for VU meters
+    // specified by ``BinaryData::Meter_140x8_png`` and ``BinaryData::Meter_140x8_pngSize``
+    // and loaded in ``VuStripesSingleton::createStripes()`` from ``juce::ImageCache``.
+
+    // total number of blocks ("LED"s) of a stripe
+    static const int totalBlocks = 46;
+
+    // dimensions of a single block (LED) in pixels (for the case of the 140x80 sized image)
+    static const int blockWidth = 2;
+    static const int blockGap = 1;
+    /*
+        // dimension of a single block in pixels (for the case of the 280x16 sized image)
+        static const int blockWidth = 2*2;
+        static const int blockGap = 1*2;
+    */
+
+    // dimension of the border
+    static const int border = 1;
+
+    // dimension of a block plus the size of a gap between two adjacent blocks
+    static const int blockWidthWithGap = blockWidth + blockGap;
+
+    // array of pointers to images of individual single stripes, 
+    // each having 0, 1, 2, ... ``totalBlocks``  bright LEDs;
+    // it is initialized by the derived classes ``VuMeter`` and
+    // ``VuMeterOutput``.
+    juce::Image** singleStripes;
+
+    // minimum dB associated to leftmost LED;
+    // (initialized now to default for the solid stripe)
+    int mindB = -46;
+
+    // minimum amplitude equivalent to mindB;
+    // (initialized now to default for the solid stripe)
+    float minamp = (float)pow(10.0, mindB * 0.1);
+
+    // maximum amplitude;
+    // (initialized now to default value for the solid stripe)
+    float maxamp = 1.0F;
+
+    // Calculates amplitude from dB value by the traditional way.
+    float dB10ToAmp(float dB);
+
+    float tenPerLog10 = (float)(10.0 / log(10.0));
+
+    // Calculates amplitude value from a dB21 value.
+    float dB2ToAmp(float dB2);
+
+    // a bias value associated to ``mindB``
+    // for the case of the approximating db21 values
+    int indexBiasMindB2 = 0;
+
+    // current amplitude value to be displayed in VU meter
+    float v = 0.0F;
+
+    VuMeterBase(int maxdB);
+    ~VuMeterBase();
+
+    // a pointer to the function to calculate index of the LED-stripe;
+    // it might point to ``ampToStripeIndex_log``, ``ampToStripeIndex_le``,
+    // or ``ampToStripeIndex_be``
+    typedef int (VuMeterBase::* funcptr_t)(float);
+    funcptr_t ampToStripeIndex;
+
+    // lookup table for the mantissa;
+    // used by the dB21-calculations
+    static const uint8_t mlut[256];
+};
+
+// A singleton to contain an array of pointers to
+// images of individual single LED-stripes.
+class VuStripesSingleton
+{
+public:
+    static VuStripesSingleton& getInstance()
+    {
+        static VuStripesSingleton instance;
+        return instance;
+    }
+
+    // total number of LEDs in a stripe
+    const static int numStripes = 47;
+    int getNumStripes() { return numStripes; };
+
+    juce::Image** getSolidVuMeterStripes() { return solidVuMeterStripes; };
+        
+    juce::Image** getTricolorVuMeterStripes() { return tricolorVuMeterStripes; };
+
+    ~VuStripesSingleton();
+
+private:
+    VuStripesSingleton();
+
+    // array of pointers to images of solid color single stripes
+    juce::Image* solidVuMeterStripes[numStripes];
+
+    // array of pointers of images of tricolor single stripes
+    juce::Image* tricolorVuMeterStripes[numStripes];
+    
+    void createStripes(juce::Image** array, bool tricolor);
+    void destroyStripes(juce::Image** array);
+};
+
+// Solid color VU Meter used to indicate output levels of the FM-operators
+// (The reference amplidute is 1.0F, implicitely.)
+class VuMeter : public VuMeterBase {
+public:
+    VuMeter();
+};
+
+// Tricolor VU Meter used for main output
+// (The reference amplidute is 1.0F, implicitely.)
+class VuMeterOutput : public VuMeterBase {
+public:
+    // number of blocks (LEDs) having different colors 
+    static const int numRedBlocks = 6;
+    static const int numYellowBlocks = 6;
+    static const int numGreenBlocks = totalBlocks - numRedBlocks - numYellowBlocks;
+
+    VuMeterOutput();
+
+    static double getDecayFactor(double sampleRate);
+};
+
+//EOF


### PR DESCRIPTION
Dear Pascal,

Please apply my current pull request. It implements faster dB-based solid-color VU meters for FM-operators and a tricolor stripe for the VU meter of the main output. 
In addition, further improvements have been introduced:
- during initialization, 47 solid color and 47 tricolor but single LED stripe images are created and stored in persitent arrays. 
The 0th element of this array shows all LEDs in dark color, the 1st element shows the leftmost LED in bright color, the 2nd element shows the two leftmost LEDs in bright color, and so on, until the last element, which contains all LEDs in bright.
- in the ``VuMeter::paint()`` method, there were previously two calls to the ``drawImage()`` method: the first one redrew the entire LED stripe in dark, and the second one redrew the leftmost LEDs in bright color. Now, there is a single call to the ``drawImageAt()`` method, which refers to the proper element of the array of images mentioned above, indexed by the dB-based scaling. (And, it is also hoped, the method ``drawImageAt()`` is faster on its own than the ``drawImage()``).
- a faster approximating dB-calculation method is implemented, if either Little Endian or Big Endian IEEE 754 4-byte sized float storage system is implemented in the given HW. (AFAIK, most CPUs belong to one of these categories); if not, the dB-calculation falls back to the traditional usage of the floating point ``log()`` function.
(Note, that I have tested the Standalone and VST3 plugin versions in MS Windows 10 OS (Intel i5-4460 CPU; MS Visual Studio 2022 Community) and the Standalone version in Raspbian OS bookworm 64-bit Linux (Broadcom BCM2711 CPU, Rasberry Pi4B), i.e. in Little Endian systems only.)