### PR TITLE
corrections of graphs for Algorithms 15 and 14

### DIFF
--- a/Source/AlgoDisplay.cpp
+++ b/Source/AlgoDisplay.cpp
@@ -228,17 +228,17 @@ void AlgoDisplay::paint(Graphics &g) {
             displayOp(g, 2, 4, 2, 0, 0);
             displayOp(g, 1, 4, 3, 2, 0);
             break;
-        case 13:
-            displayOp(g, 6, 3, 1, 0, 1);
-            displayOp(g, 5, 2, 1, 1, 0);
+        case 13:                                                                       
+            displayOp(g, 6, 4, 1, 7, 1);// displayOp(g, 6, 3, 1, 0, 1);
+            displayOp(g, 5, 3, 1, 0, 0);// displayOp(g, 5, 2, 1, 1, 0);
             displayOp(g, 4, 3, 2, 0, 0);
             displayOp(g, 3, 3, 3, 2, 0);
             displayOp(g, 2, 2, 2, 0, 0);
             displayOp(g, 1, 2, 3, 1, 0);
             break;
         case 14:
-            displayOp(g, 6, 3, 1, 0, 0);
-            displayOp(g, 5, 2, 1, 1, 0);
+            displayOp(g, 6, 4, 1, 7, 0);// displayOp(g, 6, 3, 1, 0, 0);
+            displayOp(g, 5, 3, 1, 0, 0);// displayOp(g, 5, 2, 1, 1, 0);
             displayOp(g, 4, 3, 2, 0, 0);
             displayOp(g, 3, 3, 3, 2, 0);
             displayOp(g, 2, 2, 2, 0, 4);


### PR DESCRIPTION
Dear Pascal,

apply my current Pull Request to correct two graphs of Algorithm No. 15 and No. 14, please.

Currently, the operators' graph for Algorithm No. 15 looks like this:
![Algo15-orig](https://github.com/user-attachments/assets/04a28b09-b34b-498e-85dd-ded5ff7a1e87)

The view is a bit misleading, as it suggests that the 5th and 6th operators modulate the both the 2nd and 4th operators simultaneously, but originally the 5th and 6th operators only modulate the 4th operator, not the 2nd one. Therefore, I slightly modified the image of the Algorithm No. 15 to the following:
![Algo15-new](https://github.com/user-attachments/assets/117c3c70-47ab-4d13-9da0-3494033209ff)

Furthermore, the image of the Algorithm No. 14 currently looks like it below: 
![Algo14-orig](https://github.com/user-attachments/assets/ba2add21-3120-4979-95c4-f8c41d7780a6)

However, if we compare this with the new graph of the Algorithm No. 15, the view might be confusing a bit, because there is only one essential difference between the two algorithms: namely, in the Algorithm No. 15, the 2nd operator has a feedback branch, while in the Algorithm No. 14, the 6th operator has a feedback branch; otherwise, the connection of the operators with each other is the same in both algorithms. So, for the sake of uniformity, I also modified the graph for the Algorithm No. 14 to this one:
![Algo14-new](https://github.com/user-attachments/assets/5cc98e7c-277b-47c5-ac60-5b1834a625e3)

Thank you in advance - and special thanks for releasing the new version 0.9.7!:)
