### PR TITLE
379 Cartridge Manager refractor (see original cartridge name)

### DIFF
--- a/Source/AlgoDisplay.cpp
+++ b/Source/AlgoDisplay.cpp
@@ -228,17 +228,17 @@ void AlgoDisplay::paint(Graphics &g) {
             displayOp(g, 2, 4, 2, 0, 0);
             displayOp(g, 1, 4, 3, 2, 0);
             break;
-        case 13:
-            displayOp(g, 6, 3, 1, 0, 1);
-            displayOp(g, 5, 2, 1, 1, 0);
+        case 13:                                                                       
+            displayOp(g, 6, 4, 1, 7, 1);// displayOp(g, 6, 3, 1, 0, 1);
+            displayOp(g, 5, 3, 1, 0, 0);// displayOp(g, 5, 2, 1, 1, 0);
             displayOp(g, 4, 3, 2, 0, 0);
             displayOp(g, 3, 3, 3, 2, 0);
             displayOp(g, 2, 2, 2, 0, 0);
             displayOp(g, 1, 2, 3, 1, 0);
             break;
         case 14:
-            displayOp(g, 6, 3, 1, 0, 0);
-            displayOp(g, 5, 2, 1, 1, 0);
+            displayOp(g, 6, 4, 1, 7, 0);// displayOp(g, 6, 3, 1, 0, 0);
+            displayOp(g, 5, 3, 1, 0, 0);// displayOp(g, 5, 2, 1, 1, 0);
             displayOp(g, 4, 3, 2, 0, 0);
             displayOp(g, 3, 3, 3, 2, 0);
             displayOp(g, 2, 2, 2, 0, 4);

--- a/Source/CartManager.cpp
+++ b/Source/CartManager.cpp
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright (c) 2015-2017 Pascal Gauthier.
+ * Copyright (c) 2015-2024 Pascal Gauthier.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -41,26 +41,26 @@ public:
 class FileTreeDrop : public FileTreeComponent {
 public :
     FileTreeDrop(DirectoryContentsList &listToShow) : FileTreeComponent(listToShow) {}
-    
+
     bool isInterestedInFileDrag (const StringArray &files) override {
         bool found = false;
-        
+
         for(int i=0; i<files.size(); i++) {
             String filename = files[i].toLowerCase();
             found |= filename.endsWith(".syx");
         }
         return found;
     }
-    
+
     void filesDropped(const StringArray &files, int x, int y) override {
         File targetDir = getSelectedFile();
-        
+
         if ( ! targetDir.exists() )
             targetDir = DexedAudioProcessor::dexedCartDir;
-        
+
         if ( ! targetDir.isDirectory() )
             targetDir = targetDir.getParentDirectory();
-        
+
         for(int i=0; i<files.size(); i++) {
             if ( files[i].toLowerCase().endsWith(".syx") ) {
                 File src(files[i]);
@@ -74,65 +74,61 @@ public :
 
 CartManager::CartManager(DexedAudioProcessorEditor *editor) : Component("CartManager") {
     mainWindow = editor;
-    cartDir = DexedAudioProcessor::dexedCartDir;            
-            
+    cartDir = DexedAudioProcessor::dexedCartDir;
+
     activeCart.reset(new ProgramListBox("activepgm", 8));
     addAndMakeVisible(activeCart.get());
-    activeCart->setBounds(28, 441, 800, 96);
     activeCart->addListener(this);
-            
+
     browserCart.reset(new ProgramListBox("browserpgm", 2));
     addAndMakeVisible(browserCart.get());
-    browserCart->setBounds(635, 18, 200, 384);
     browserCart->addListener(this);
-    
+
     // -------------------------
     syxFileFilter.reset(new SyxFileFilter());
     timeSliceThread.reset(new TimeSliceThread("Cartridge Directory Scanner"));
     timeSliceThread->startThread();
-    
+
     cartBrowserList.reset(new DirectoryContentsList(syxFileFilter.get(), *timeSliceThread.get()));
     cartBrowserList->setDirectory(cartDir, true, true);
     cartBrowser.reset(new FileTreeDrop(*cartBrowserList));
     cartBrowser->addKeyListener(this);
     addAndMakeVisible(cartBrowser.get());
-    
-    cartBrowser->setBounds(23, 18, 590, 384);
+
     cartBrowser->setDragAndDropDescription("Sysex Browser");
     cartBrowser->addListener(this);
-    
+
     closeButton.reset(new TextButton("CLOSE"));
     addAndMakeVisible(closeButton.get());
-    closeButton->setBounds(4, 545, 50, 30);
     closeButton->addListener(this);
 
     loadButton.reset(new TextButton("LOAD"));
     addAndMakeVisible(loadButton.get());
-    loadButton->setBounds(52, 545, 50, 30);
     loadButton->addListener(this);
-    
+
     saveButton.reset(new TextButton("SAVE"));
     addAndMakeVisible(saveButton.get());
-    saveButton->setBounds(100, 545, 50, 30);
     saveButton->addListener(this);
 
     fileMgrButton.reset(new TextButton("SHOW DIR"));
     addAndMakeVisible(fileMgrButton.get());
-    fileMgrButton->setBounds(148, 545, 70, 30);
     fileMgrButton->addListener(this);
+
+    activeCartName.reset(new Label("activeCart"));
+    addAndMakeVisible(activeCartName.get());
+    updateCartFilename();
 /*
  *
  * I've removed this since it only works on the DX7 II. TBC.
  *
-
     addAndMakeVisible(getDXPgmButton = new TextButton("GET DX7 PGM"));
     getDXPgmButton->setBounds(656, 545, 100, 30);
     getDXPgmButton->addListener(this);
-            
+
     addAndMakeVisible(getDXCartButton = new TextButton("GET DX7 CART"));
     getDXCartButton->setBounds(755, 545, 100, 30);
     getDXCartButton->addListener(this);
-*/
+ */
 }
 
 CartManager::~CartManager() {
@@ -141,12 +137,31 @@ CartManager::~CartManager() {
     cartBrowserList.reset(NULL);
 }
 
+void CartManager::resized() {
+    float activeSize = ((float) getWidth() - 30) / 8;
+
+    activeCart->setBounds(15, 402, activeSize * 8, 96);
+    browserCart->setBounds(activeSize * 6 + 15, 10, activeSize * 2, 384);
+    cartBrowser->setBounds(15, 10, activeSize * 6 - 1, 383);
+    closeButton->setBounds(4, getHeight() - 40, 50, 30);
+    saveButton->setBounds(100, getHeight() - 40, 50, 30);
+    loadButton->setBounds(52, getHeight() - 40, 50, 30);
+    fileMgrButton->setBounds(148, getHeight() - 40, 70, 30);
+    activeCartName->setBounds(getWidth() - 30 - 100, getHeight() - 40, 100, 30);
+}
+
 void CartManager::paint(Graphics &g) {
     g.fillAll(DXLookNFeel::lightBackground);
-    g.setColour(DXLookNFeel::roundBackground);
+/*    g.setColour(DXLookNFeel::roundBackground);
     g.fillRoundedRectangle(8, 418, 843, 126, 15);
     g.setColour(Colours::whitesmoke);
-    g.drawText("currently loaded cartridge", 38, 410, 150, 40, Justification::left);
+    g.drawText("currently loaded cartridge", 38, 410, 150, 40, Justification::left);*/
+}
+
+void CartManager::updateCartFilename() {
+    if ( mainWindow->processor->activeFileCartridge.exists() )
+        DBG("OK");
+        /*activeCartName->setText(mainWindow->processor->activeFileCartridge.getFileName(), NotificationType::dontSendNotification);*/
 }
 
 void CartManager::programSelected(ProgramListBox *source, int pos) {
@@ -171,19 +186,19 @@ void CartManager::buttonClicked(juce::Button *buttonThatWasClicked) {
         setVisible(false);
         return;
     }
-    
+
     if ( buttonThatWasClicked == loadButton.get() ) {
         FileChooser fc ("Import original DX sysex...", File::getSpecialLocation(File::SpecialLocationType::userDocumentsDirectory), "*.syx;*.SYX;*.*", 1);
-        
+
         if ( fc.browseForFileToOpen())
             mainWindow->loadCart(fc.getResult());
         return;
     }
-    
+
     if ( buttonThatWasClicked == saveButton.get() ) {
         mainWindow->saveCart();
     }
-    
+
     if ( buttonThatWasClicked == fileMgrButton.get() ) {
         cartDir.revealToUser();
         return;
@@ -199,7 +214,7 @@ void CartManager::buttonClicked(juce::Button *buttonThatWasClicked) {
         }
         return;
     }
-    
+
     if ( buttonThatWasClicked == getDXCartButton.get() ) {
         if ( mainWindow->processor->sysexComm.isInputActive() && mainWindow->processor->sysexComm.isOutputActive() ) {
             unsigned char msg[] = { 0xF0, 0x43, 0x20, 0x00, 0xF7 };
@@ -221,14 +236,14 @@ void CartManager::fileDoubleClicked(const File& file) {
 void CartManager::fileClicked(const File& file, const MouseEvent& e) {
     if ( e.mods.isPopupMenu()) {
         PopupMenu menu;
-        
+
         menu.addItem(1000, "Open location");
         if ( ! file.isDirectory() ) {
             menu.addItem(1010, "Send sysex cartridge to DX7");
         }
         menu.addSeparator();
         menu.addItem(1020, "Refresh");
-        
+
         switch(menu.show()) {
         case 1000:
             file.revealToUser();
@@ -261,17 +276,17 @@ void CartManager::selectionChanged() {
 
     if ( ! file.exists() )
         return;
-    
+
     if ( file.isDirectory() )
         return;
-    
+
     Cartridge browserSysex;
     int rc = browserSysex.load(file);
     if ( rc < 0 ) {
         AlertWindow::showMessageBoxAsync (AlertWindow::WarningIcon, "Error", "Unable to open file");
         return;
     }
-    
+
     if ( rc != 0 ) {
         browserCart->readOnly = true;
     } else {
@@ -283,22 +298,22 @@ void CartManager::selectionChanged() {
 
 void CartManager::programRightClicked(ProgramListBox *source, int pos) {
     PopupMenu menu;
-    
+
     menu.addItem(1000, "Send program '" + source->programNames[pos] + "' to DX7");
-    
+
     if ( source == activeCart.get() )
         menu.addItem(1010, "Send current sysex cartridge to DX7");
 
     switch(menu.show())  {
         case 1000:
             uint8_t unpackPgm[161];
-            
+
             if ( source == activeCart.get() ) {
                 mainWindow->processor->currentCart.unpackProgram(unpackPgm, pos);
             } else {
                 source->getCurrentCart().unpackProgram(unpackPgm, pos);
             }
-            
+
             if ( mainWindow->processor->sysexComm.isOutputActive() ) {
                 uint8_t msg[163];
                 exportSysexPgm(msg, unpackPgm);
@@ -306,7 +321,7 @@ void CartManager::programRightClicked(ProgramListBox *source, int pos) {
                 mainWindow->processor->sysexComm.send(MidiMessage(msg, 163));
             }
             break;
-            
+
         case 1010:
             mainWindow->processor->sendCurrentSysexCartridge();
             break;
@@ -321,10 +336,10 @@ void CartManager::programDragged(ProgramListBox *destListBox, int dest, char *pa
         mainWindow->updateUI();
     } else {
         File file = cartBrowser->getSelectedFile();
-        
+
         if ( ! file.exists() )
             return;
-        
+
         if ( file.isDirectory() )
             return;
         if ( file.getSize() != 4104 && file.getSize() != 4096 )

--- a/Source/CartManager.cpp
+++ b/Source/CartManager.cpp
@@ -25,7 +25,6 @@
 #include "PluginData.h"
 
 #include <fstream>
-using namespace ::std;
 
 class SyxFileFilter : public FileFilter {
 public:
@@ -114,9 +113,9 @@ CartManager::CartManager(DexedAudioProcessorEditor *editor) : Component("CartMan
     addAndMakeVisible(fileMgrButton.get());
     fileMgrButton->addListener(this);
 
-    activeCartName.reset(new Label("activeCart"));
+    activeCartName.reset(new CartridgeFileDisplay());
     addAndMakeVisible(activeCartName.get());
-    updateCartFilename();
+
 /*
  *
  * I've removed this since it only works on the DX7 II. TBC.
@@ -143,25 +142,19 @@ void CartManager::resized() {
     activeCart->setBounds(15, 402, activeSize * 8, 96);
     browserCart->setBounds(activeSize * 6 + 15, 10, activeSize * 2, 384);
     cartBrowser->setBounds(15, 10, activeSize * 6 - 1, 383);
-    closeButton->setBounds(4, getHeight() - 40, 50, 30);
-    saveButton->setBounds(100, getHeight() - 40, 50, 30);
-    loadButton->setBounds(52, getHeight() - 40, 50, 30);
-    fileMgrButton->setBounds(148, getHeight() - 40, 70, 30);
-    activeCartName->setBounds(getWidth() - 30 - 100, getHeight() - 40, 100, 30);
+    closeButton->setBounds(4, getHeight() - 40, 70, 30);
+    saveButton->setBounds(144, getHeight() - 40, 70, 30);
+    loadButton->setBounds(74, getHeight() - 40, 70, 30);
+    fileMgrButton->setBounds(214, getHeight() - 40, 90, 30);
+    activeCartName->setBounds(getWidth() - 8 - 300, getHeight() - 40, 300, 30);
 }
 
 void CartManager::paint(Graphics &g) {
     g.fillAll(DXLookNFeel::lightBackground);
-/*    g.setColour(DXLookNFeel::roundBackground);
-    g.fillRoundedRectangle(8, 418, 843, 126, 15);
-    g.setColour(Colours::whitesmoke);
-    g.drawText("currently loaded cartridge", 38, 410, 150, 40, Justification::left);*/
 }
 
 void CartManager::updateCartFilename() {
-    if ( mainWindow->processor->activeFileCartridge.exists() )
-        DBG("OK");
-        /*activeCartName->setText(mainWindow->processor->activeFileCartridge.getFileName(), NotificationType::dontSendNotification);*/
+    activeCartName->setCartrdigeFile(mainWindow->processor->activeFileCartridge);
 }
 
 void CartManager::programSelected(ProgramListBox *source, int pos) {
@@ -183,15 +176,17 @@ void CartManager::programSelected(ProgramListBox *source, int pos) {
 void CartManager::buttonClicked(juce::Button *buttonThatWasClicked) {
     if ( buttonThatWasClicked == closeButton.get() ) {
         mainWindow->startTimer(100);
-        setVisible(false);
+        getParentComponent()->setVisible(false);
         return;
     }
 
     if ( buttonThatWasClicked == loadButton.get() ) {
         FileChooser fc ("Import original DX sysex...", File::getSpecialLocation(File::SpecialLocationType::userDocumentsDirectory), "*.syx;*.SYX;*.*", 1);
 
-        if ( fc.browseForFileToOpen())
+        if ( fc.browseForFileToOpen()) {
             mainWindow->loadCart(fc.getResult());
+            updateCartFilename();
+        }
         return;
     }
 
@@ -231,6 +226,7 @@ void CartManager::fileDoubleClicked(const File& file) {
         return;
     mainWindow->loadCart(file);
     activeCart->setCartridge(mainWindow->processor->currentCart);
+    updateCartFilename();
 }
 
 void CartManager::fileClicked(const File& file, const MouseEvent& e) {

--- a/Source/CartManager.h
+++ b/Source/CartManager.h
@@ -35,18 +35,19 @@ class CartManager  : public Component, public Button::Listener, public DragAndDr
     std::unique_ptr<TextButton> fileMgrButton;
     std::unique_ptr<TextButton> getDXPgmButton;
     std::unique_ptr<TextButton> getDXCartButton;
-    
+
     std::unique_ptr<ProgramListBox> activeCart;
     std::unique_ptr<ProgramListBox> browserCart;
-    
+
     std::unique_ptr<FileFilter> syxFileFilter;
-        
+
     std::unique_ptr<FileTreeComponent> cartBrowser;
     std::unique_ptr<TimeSliceThread> timeSliceThread;
     std::unique_ptr<DirectoryContentsList> cartBrowserList;
-        
+    std::unique_ptr<Label> activeCartName;
+
     File cartDir;
-    
+
     DexedAudioProcessorEditor *mainWindow;
 
     void showSysexConfigMsg();
@@ -56,22 +57,25 @@ public:
     virtual ~CartManager();
     void paint(Graphics& g) override;
     void buttonClicked (Button* buttonThatWasClicked) override;
-    
+
     void selectionChanged() override;
     void fileClicked (const File& file, const MouseEvent& e) override;
     void fileDoubleClicked (const File& file) override;
     void browserRootChanged (const File& newRoot) override;
-        
+
     void setActiveProgram(int idx, String activeName);
     void resetActiveSysex();
-        
+
+    void updateCartFilename();
+
+    void resized() override;
+
     virtual void programSelected(ProgramListBox *source, int pos) override;
     virtual void programRightClicked(ProgramListBox *source, int pos) override;
     virtual void programDragged(ProgramListBox *destListBox, int dest, char *packedPgm) override;
     virtual bool keyPressed(const KeyPress& key, Component* originatingComponent) override;
-        
+
     void initialFocus();
 };
-
 
 #endif  // CARTMANAGER_H_INCLUDED

--- a/Source/CartManager.h
+++ b/Source/CartManager.h
@@ -26,6 +26,37 @@
 #include "ProgramListBox.h"
 #include "PluginData.h"
 
+class CartridgeFileDisplay : public Component {
+    File file;
+    float clickableArea = 0;
+public:
+    void setCartrdigeFile(File &file) {
+        this->file = file;
+        repaint();
+    }
+
+    void paint(Graphics& g) override {
+        g.setColour(Colours::whitesmoke);
+        if ( file.exists() ) {
+            g.setFont(g.getCurrentFont().withStyle(Font::underlined));
+            clickableArea = g.getCurrentFont().getStringWidthFloat(file.getFileName());
+            g.drawText(file.getFileName(), 0, 0, getWidth(), getHeight(), Justification::right);
+            g.setFont(g.getCurrentFont().withStyle(Font::plain));
+            g.drawText("Based on cartridge: ", 0, 0, getWidth() - (clickableArea + 2), getHeight(), Justification::right);
+        } else {
+            g.drawText("[No reference to original cartridge]", 0, 0, getWidth(), getHeight(), Justification::right);
+            clickableArea = 0;
+        }
+    }
+
+    void mouseDown(const MouseEvent &event) override {
+        if ( event.getMouseDownX() > getWidth() - clickableArea ) {
+            if ( file.exists() )
+                file.revealToUser();
+        }
+    }
+};
+
 class CartManager  : public Component, public Button::Listener, public DragAndDropContainer, public FileBrowserListener
     , public ProgramListBoxListener, public KeyListener {
     std::unique_ptr<TextButton> newButton;
@@ -44,7 +75,7 @@ class CartManager  : public Component, public Button::Listener, public DragAndDr
     std::unique_ptr<FileTreeComponent> cartBrowser;
     std::unique_ptr<TimeSliceThread> timeSliceThread;
     std::unique_ptr<DirectoryContentsList> cartBrowserList;
-    std::unique_ptr<Label> activeCartName;
+    std::unique_ptr<CartridgeFileDisplay> activeCartName;
 
     File cartDir;
 

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -106,7 +106,7 @@ void DexedAudioProcessorEditor::paint (Graphics& g) {
 void DexedAudioProcessorEditor::cartShow() {
     stopTimer();    
     cartManager.resetActiveSysex();
-    cartManager.setBounds(4, 2, 859, 576);
+    cartManager.setBounds(16, 16, WINDOW_SIZE_X - 32, WINDOW_SIZE_Y - 94 - 32);
     cartManager.setVisible(true);
     cartManager.initialFocus();
 }

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -39,7 +39,7 @@ DexedAudioProcessorEditor::DexedAudioProcessorEditor (DexedAudioProcessor* owner
     setSize(WINDOW_SIZE_X, (ownerFilter->showKeyboard ? WINDOW_SIZE_Y : WINDOW_SIZE_Y - 94));
 
     processor = ownerFilter;
-    
+
     lookAndFeel->setDefaultLookAndFeel(lookAndFeel);
     background = lookAndFeel->background;
 
@@ -47,30 +47,30 @@ DexedAudioProcessorEditor::DexedAudioProcessorEditor (DexedAudioProcessor* owner
     addAndMakeVisible(&(operators[0]));
     operators[0].setBounds(2, 1, 287, 218);
     operators[0].bind(processor, 0);
-    
+
     addAndMakeVisible(&(operators[1]));
     operators[1].setBounds(290, 1, 287, 218);
     operators[1].bind(processor, 1);
-    
+
     addAndMakeVisible(&(operators[2]));
     operators[2].setBounds(578, 1, 287, 218);
     operators[2].bind(processor, 2);
-    
+
     addAndMakeVisible(&(operators[3]));
     operators[3].setBounds(2, 219, 287, 218);
     operators[3].bind(processor, 3);
-    
+
     addAndMakeVisible(&(operators[4]));
     operators[4].setBounds(290, 219, 287, 218);
     operators[4].bind(processor, 4);
-    
+
     addAndMakeVisible(&(operators[5]));
     operators[5].setBounds(578, 219, 287, 218);
     operators[5].bind(processor, 5);
 
     // add the midi keyboard component..
     addAndMakeVisible (&midiKeyboard);
-    
+
     // The DX7 is a badass on the bass, keep it that way
     midiKeyboard.setLowestVisibleKey(24);
 
@@ -79,12 +79,12 @@ DexedAudioProcessorEditor::DexedAudioProcessorEditor (DexedAudioProcessor* owner
     addAndMakeVisible(&global);
     global.setBounds(2,436,864,144);
     global.bind(this);
-    
+
     global.setMonoState(processor->isMonoMode());
-    
+
     rebuildProgramCombobox();
     global.programs->addListener(this);
-    
+
     addChildComponent(&cartManagerCover);
     cartManagerCover.addChildComponent(&cartManager);
     cartManager.setVisible(true);
@@ -100,33 +100,33 @@ DexedAudioProcessorEditor::~DexedAudioProcessorEditor() {
 }
 
 //==============================================================================
-void DexedAudioProcessorEditor::paint (Graphics& g) {    
+void DexedAudioProcessorEditor::paint (Graphics& g) {
     g.setColour(background);
     g.fillRoundedRectangle(0.0f, 0.0f, (float) getWidth(), (float) getHeight(), 0);
 }
 
 void DexedAudioProcessorEditor::cartShow() {
-    stopTimer();    
+    stopTimer();
     cartManager.resetActiveSysex();
     cartManagerCover.setBounds(0, 0, WINDOW_SIZE_X , WINDOW_SIZE_Y - 94);
     cartManager.setBounds(16, 16, cartManagerCover.getWidth() - 32, cartManagerCover.getHeight() - 32);
     cartManager.updateCartFilename();
-    cartManager.initialFocus();
     cartManagerCover.setVisible(true);
+    cartManager.initialFocus();
 }
 
 void DexedAudioProcessorEditor::loadCart(File file) {
     Cartridge cart;
 
     int rc = cart.load(file);
-    
+
     if ( rc < 0 ) {
         AlertWindow::showMessageBoxAsync (AlertWindow::WarningIcon,
                                           "Error",
                                           "Unable to open: " + file.getFullPathName());
         return;
     }
-    
+
     if ( rc != 0 ) {
         rc = AlertWindow::showOkCancelBox(AlertWindow::QuestionIcon, "Unable to find DX7 sysex cartridge in file",
                                           "This sysex file is not for the DX7 or it is corrupted. "
@@ -134,13 +134,13 @@ void DexedAudioProcessorEditor::loadCart(File file) {
         if ( rc == 0 )
             return;
     }
-    
+
     processor->loadCartridge(cart);
     rebuildProgramCombobox();
     processor->setCurrentProgram(0);
     global.programs->setSelectedId(processor->getCurrentProgram()+1, dontSendNotification);
     processor->updateHostDisplay();
-    
+
     processor->activeFileCartridge = file;
 }
 
@@ -160,7 +160,7 @@ void DexedAudioProcessorEditor::saveCart() {
 void DexedAudioProcessorEditor::tuningShow() {
     auto te = new TuningShow();
     te->setTuning( processor->synthTuningState->getTuning() );
-    
+
     DialogWindow::LaunchOptions options;
     options.content.setOwned(te);
     options.dialogTitle = "Current Tuning";
@@ -243,7 +243,7 @@ void DexedAudioProcessorEditor::timerCallback() {
         processor->forceRefreshUI = false;
         updateUI();
     }
-    
+
     if ( ! processor->peekVoiceStatus() )
         return;
 
@@ -265,7 +265,7 @@ void DexedAudioProcessorEditor::timerCallback() {
     }
     global.updatePitchPos(processor->voiceStatus.pitchStep);
     global.updateVu(processor->vuSignal);
-}   
+}
 
 void DexedAudioProcessorEditor::updateUI() {
     for(int i=0;i<processor->ctrl.size();i++) {
@@ -281,22 +281,22 @@ void DexedAudioProcessorEditor::updateUI() {
 
 void DexedAudioProcessorEditor::rebuildProgramCombobox() {
     global.programs->clear(dontSendNotification);
-    
+
     processor->currentCart.getProgramNames(processor->programNames);
-    
+
     for(int i=0;i<processor->getNumPrograms();i++) {
         String id;
         id << (i+1) << ". " << processor->getProgramName(i);
         global.programs->addItem(id, i+1);
     }
-    
+
     global.programs->setSelectedId(processor->getCurrentProgram()+1, dontSendNotification);
-    
+
     String name = Cartridge::normalizePgmName((const char *) processor->data+145);
     cartManager.setActiveProgram(processor->getCurrentProgram(), name);
     if ( name != processor->getProgramName(processor->getCurrentProgram()) )
         global.programs->setText("**. " + name, dontSendNotification);
-    
+
     cartManager.resetActiveSysex();
 }
 
@@ -306,10 +306,10 @@ void DexedAudioProcessorEditor::storeProgram() {
     File *externalFile = NULL;
 
     bool activeCartridgeFound = processor->activeFileCartridge.exists();
-    
+
     while (true) {
         String msg;
-        
+
         if ( externalFile == NULL ) {
             if ( activeCartridgeFound )
                 msg = "Store program to current (" + processor->activeFileCartridge.getFileName() + ") / new cartridge";
@@ -318,7 +318,7 @@ void DexedAudioProcessorEditor::storeProgram() {
         } else {
             msg = "Store program to " + externalFile->getFileName();
         }
-        
+
         AlertWindow dialog("Store Program", msg, AlertWindow::NoIcon, this);
         dialog.addTextEditor("Name", currentName, String("Name"), false);
         // TODO: fix the name length to 10
@@ -333,10 +333,10 @@ void DexedAudioProcessorEditor::storeProgram() {
             saveAction.add("Store program and create a new copy of the .syx cartridge");
             if ( activeCartridgeFound )
                 saveAction.add("Store program and overwrite current .syx cartridge");
-        
+
             dialog.addComboBox("SaveAction", saveAction, "Store Action");
         }
-                
+
         dialog.addButton("OK", 0, KeyPress(KeyPress::returnKey));
         dialog.addButton("CANCEL", 1, KeyPress(KeyPress::escapeKey));
         dialog.addButton("EXTERNAL FILE", 2, KeyPress());
@@ -359,7 +359,7 @@ void DexedAudioProcessorEditor::storeProgram() {
         if ( response == 0 ) {
             TextEditor *name = dialog.getTextEditor("Name");
             ComboBox *dest = dialog.getComboBoxComponent("Dest");
-            
+
             int programNum = dest->getSelectedItemIndex();
             String programName(name->getText());
             if ( programName.length() > 10 ) {
@@ -372,9 +372,9 @@ void DexedAudioProcessorEditor::storeProgram() {
                 rebuildProgramCombobox();
                 processor->setCurrentProgram(programNum);
                 processor->updateHostDisplay();
-                
+
                 int action = dialog.getComboBoxComponent("SaveAction")->getSelectedItemIndex();
-                if ( action > 0 ) {                  
+                if ( action > 0 ) {
                     File destination = processor->activeFileCartridge;
                     if ( action == 1 ) {
                         FileChooser fc("Destination Sysex", processor->dexedCartDir, "*.syx;*.SYX", 1);
@@ -382,7 +382,7 @@ void DexedAudioProcessorEditor::storeProgram() {
                             break;
                         destination = fc.getResult();
                     }
-                    
+
                     processor->currentCart.saveVoice(destination);
                     processor->activeFileCartridge = destination;
                 }
@@ -410,14 +410,14 @@ public :
         this->target = target;
         setMessage("Mapping: " + String(target->label) + ", waiting for midi controller change (CC) message...");
         addButton("CANCEL", -1);
-        editor->processor->lastCCUsed.setValue(-1);        
+        editor->processor->lastCCUsed.setValue(-1);
         editor->processor->lastCCUsed.addListener(this);
     }
-    
+
     ~MidiCCListener() {
         editor->processor->lastCCUsed.removeListener(this);
     }
-    
+
     void valueChanged(Value &value) {
         int cc = value.getValue();
         editor->processor->mappedMidiCC.remove(cc);
@@ -435,7 +435,7 @@ void DexedAudioProcessorEditor::discoverMidiCC(Ctrl *ctrl) {
 bool DexedAudioProcessorEditor::isInterestedInFileDrag (const StringArray &files)
 {
     if( files.size() != 1 ) return false;
-    
+
     for( auto i = files.begin(); i != files.end(); ++i )
     {
         if( i->endsWithIgnoreCase( ".scl" ) || i->endsWithIgnoreCase( ".kbm" ) )

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -85,8 +85,10 @@ DexedAudioProcessorEditor::DexedAudioProcessorEditor (DexedAudioProcessor* owner
     rebuildProgramCombobox();
     global.programs->addListener(this);
     
-    addChildComponent(&cartManager);
-    
+    addChildComponent(&cartManagerCover);
+    cartManagerCover.addChildComponent(&cartManager);
+    cartManager.setVisible(true);
+
     updateUI();
     startTimer(100);
 }
@@ -106,11 +108,12 @@ void DexedAudioProcessorEditor::paint (Graphics& g) {
 void DexedAudioProcessorEditor::cartShow() {
     stopTimer();    
     cartManager.resetActiveSysex();
-    cartManager.setBounds(16, 16, WINDOW_SIZE_X - 32, WINDOW_SIZE_Y - 94 - 32);
-    cartManager.setVisible(true);
+    cartManagerCover.setBounds(0, 0, WINDOW_SIZE_X , WINDOW_SIZE_Y - 94);
+    cartManager.setBounds(16, 16, cartManagerCover.getWidth() - 32, cartManagerCover.getHeight() - 32);
+    cartManager.updateCartFilename();
     cartManager.initialFocus();
+    cartManagerCover.setVisible(true);
 }
-
 
 void DexedAudioProcessorEditor::loadCart(File file) {
     Cartridge cart;
@@ -273,6 +276,7 @@ void DexedAudioProcessorEditor::updateUI() {
     }
     rebuildProgramCombobox();
     global.updateDisplay();
+    cartManager.updateCartFilename();
 }
 
 void DexedAudioProcessorEditor::rebuildProgramCombobox() {

--- a/Source/PluginEditor.h
+++ b/Source/PluginEditor.h
@@ -37,6 +37,8 @@ class DexedAudioProcessorEditor  : public AudioProcessorEditor, public ComboBox:
     OperatorEditor operators[6];
     Colour background;
     CartManager cartManager;
+    // This cover is used to disable main window when cart manager is shown
+    Component cartManagerCover;
 
     SharedResourcePointer<DXLookNFeel> lookAndFeel;
 public:

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -301,8 +301,9 @@ void DexedAudioProcessor::processBlock(AudioSampleBuffer& buffer, MidiBuffer& mi
             vuSignal = 0;
     }
     
-    // DX7 is a mono synth
-    buffer.copyFrom(1, 0, channelData, numSamples, 1);
+    // DX7 is a mono synth, but copy it to the right channel is available
+    if ( buffer.getNumChannels() > 1 )
+        buffer.copyFrom(1, 0, channelData, numSamples, 1);
 }
 
 


### PR DESCRIPTION
The Cartridge Manager needed a haircut. If you click on the cartridge name on the right bottom it will open the OS file browser for this cartridge.

Comments are welcomed. 

Dev builds are available here : https://github.com/asb2m10/dexed/actions/runs/10032291816

This should close #379 and (already closed duplicate #374)

![image](https://github.com/user-attachments/assets/a48d0ab9-325e-44ee-b0ff-3ec95344c5b7)
