### PR TITLE
code cleanup for MidiMonitor

### DIFF
--- a/Source/GlobalEditor.cpp
+++ b/Source/GlobalEditor.cpp
@@ -31,14 +31,25 @@
  * Ugly but useful midi monitor to know if you are really sending/receiving something from the DX7
  * If the midi is not configured this component wont show up
  *
+ */
+#ifdef IMPLEMENT_MidiMonitor
 class MidiMonitor : public Component {
     SysexComm *midi;
     Image light;
+    int imageHeight;
+    int imageHeight2;
+    int imageWidth;
 
+    SharedResourcePointer<DXLookNFeel> lookAndFeel; 
 public:
     MidiMonitor(SysexComm *sysexComm) {
         midi = sysexComm;
-        light = DXLookNFeel::getLookAndFeel()->imageLight;
+        light = lookAndFeel->imageLight;
+        imageHeight = light.getHeight();
+        imageHeight2 = imageHeight / 2;
+        imageWidth = light.getWidth();
+
+        TRACE("WARNING! This functionality is a candidate for deprecation/obsolescence!");
     }
 
     void paint(Graphics &g) {
@@ -47,24 +58,25 @@ public:
         g.setColour(Colours::white);
 
         if ( midi->isInputActive() ) {
-            g.drawSingleLineText("DX7 IN", 17,14);
-            g.drawImage(light, 0, 3, 14, 14, 0, midi->inActivity ? 14 : 0, 14, 14);
+            g.drawSingleLineText("DX7 IN", 24, 18);
+            g.drawImage(light, 0, 0, imageWidth, imageHeight2, 0, midi->inActivity ? imageHeight2 : 0, imageWidth, imageHeight2);
             midi->inActivity = false;
         }
 
         if ( midi->isOutputActive() ) {
-            g.drawSingleLineText("DX7 OUT", 17, 28);
-            g.drawImage(light, 0, 17, 14, 14, 0, midi->outActivity ? 14 : 0, 14, 14);
+            g.drawSingleLineText("DX7 OUT", 24, 36);
+            g.drawImage(light, 0, 18, imageWidth, imageHeight2, 0, midi->outActivity ? imageHeight2 : 0, imageWidth, imageHeight2);
             midi->outActivity = false;
         }
     }
-};*/
+};
+#endif //IMPLEMENT_MidiMonitor
 
 class AboutBox : public DialogWindow {
 public:
     Image logo_png;
     std::unique_ptr<juce::HyperlinkButton> dexed; // changed to std::unique_ptr from juce::ScopedPointer
-    std::unique_ptr<juce::HyperlinkButton> surge; // changed to std__unique_ptr from juce::ScopedPointer
+    std::unique_ptr<juce::HyperlinkButton> surge; // changed to std::unique_ptr from juce::ScopedPointer
 
     AboutBox(Component *parent) : DialogWindow("About", Colour(0xFF000000), true),
         dexed(std::make_unique<juce::HyperlinkButton>("https://asb2m10.github.io/dexed/", URL("https://asb2m10.github.io/dexed/"))),
@@ -706,9 +718,11 @@ void GlobalEditor::bind(DexedAudioProcessorEditor *edit) {
 
     editor = edit;
 
-    //midiMonitor = new MidiMonitor(&(processor->sysexComm));
-    //addAndMakeVisible(midiMonitor);
-    //midiMonitor->setBounds(155, 21, 80, 45);
+#ifdef IMPLEMENT_MidiMonitor
+    midiMonitor = std::make_unique<MidiMonitor>(&(processor->sysexComm));
+    addAndMakeVisible(*midiMonitor);
+    midiMonitor->setBounds(110, 10, 80, 45);    //midiMonitor->setBounds(155, 21, 80, 45);
+#endif //IMPLEMENT_MidiMonitor
 
     repaint();
 }
@@ -734,7 +748,9 @@ void GlobalEditor::updatePitchPos(int pos) {
 void GlobalEditor::updateVu(float f) {
     vuOutput->v = f;
     vuOutput->repaint();
-    //midiMonitor->repaint();
+#ifdef IMPLEMENT_MidiMonitor
+    midiMonitor->repaint();
+#endif //IMPLEMENT_MidiMonitor
 }
 
 void GlobalEditor::setMonoState(bool state)  {

--- a/Source/GlobalEditor.h
+++ b/Source/GlobalEditor.h
@@ -25,6 +25,10 @@
 #include "DXComponents.h"
 #include "AlgoDisplay.h"
 
+#ifdef IMPLEMENT_MidiMonitor
+#include "SysexComm.h"
+#endif // IMPLEMENT_MidiMonitor
+
 class DexedAudioProcessorEditor;
 //[/Headers]
 
@@ -59,7 +63,10 @@ public:
 
     void setMonoState(bool state);
     ProgramSelector *programs;
-    //std::unique_ptr<Component> midiMonitor;
+
+#ifdef IMPLEMENT_MidiMonitor
+    std::unique_ptr<Component> midiMonitor;
+#endif //IMPLEMENT_MidiMonitor
 
     void mouseDown(const MouseEvent& e) override;
     //[/UserMethods]

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -600,7 +600,9 @@ void DexedAudioProcessor::handleIncomingMidiMessage(MidiInput* source, const Mid
     if ( message.isActiveSense() ) 
         return;
 
-    sysexComm.inActivity = true;
+#ifdef IMPLEMENT_MidiMonitor
+    sysexComm.inActivity = true; // indicate to MidiMonitor that a MIDI messages (other than Active Sense) is received
+#endif //IMPLEMENT_MidiMonitor
 
     const uint8 *buf = message.getRawData();
     int sz = message.getRawDataSize();

--- a/Source/SysexComm.cpp
+++ b/Source/SysexComm.cpp
@@ -31,6 +31,11 @@ SysexComm::SysexComm() {
     input = NULL;
     output = NULL;
     inputOutput = false;
+
+#ifdef IMPLEMENT_MidiMonitor
+    inActivity = false;
+    outActivity = false;
+#endif //IMPLEMENT_MidiMonitor
 }
 
 String SysexComm::getInput() {
@@ -38,9 +43,11 @@ String SysexComm::getInput() {
 }
 
 bool SysexComm::setInput(String target) {
+#ifndef IMPLEMENT_MidiMonitor
     if ( JUCEApplication::isStandaloneApp() )
         return true;
-    
+#endif
+
     if ( input != NULL ) {
         input->stop();
         input = NULL;
@@ -132,7 +139,11 @@ void SysexComm::setChl(int chl) {
 int SysexComm::send(const MidiMessage &message) {
     if ( output == NULL )
         return 2;
-    outActivity = true;
+
+#ifdef IMPLEMENT_MidiMonitor
+    outActivity = true; // indicate to MidiMonitor that a MIDI message is going to be sent
+#endif // IMPLEMENT_MidiMonitor
+
     output->sendMessageNow(message);
     return 0;
 }

--- a/Source/SysexComm.h
+++ b/Source/SysexComm.h
@@ -23,6 +23,15 @@
 
 #include "../JuceLibraryCode/JuceHeader.h"
 
+ // If the macro ''IMPLEMENT_MidiMonitor'' is defined,
+ // then the class ''MidiMonitor'' and its related variables 
+ // and invocations from other parts are implemented.
+ // If the macro is not defined the related source snippets are excluded.
+ // WARNING: this class and related variables and invocations 
+ // are very likely candidates for deprecation / obsolescence,
+ // so it is NOT RECOMMENDED to define this macro!
+ //#define IMPLEMENT_MidiMonitor
+
 class SysexComm {
     std::unique_ptr<MidiInput> input;
     std::unique_ptr<MidiOutput> output;
@@ -35,9 +44,10 @@ class SysexComm {
     MidiBuffer noteOutput;
 public :
     MidiInputCallback *listener;
+#ifdef IMPLEMENT_MidiMonitor
     bool inActivity;
     bool outActivity;
-    
+#endif //IMPLEMENT_MidiMonitor    
     SysexComm();
     
     bool setInput(String name);


### PR DESCRIPTION
Dear Pascal,
Now I am sending the one of the parts after splitting the [simplified AlignedBuf, corrected dexedTheme, code purification related to MidiMonitor #434](https://github.com/asb2m10/dexed/pull/434) in this PR; it contains only the corrections related to ``MidiMonitor`` class.
Unfortunately, another issue has arisen regarding DexedTheme (the build-macos step failed), so there is still work to be done there.
Furthermore, I have not yet found a good and general solution for ``AlignedBuf`` that would extend to older C++ compilers as well.
So for now, I’m just sending only this single PRs, (hoping that it can pass without further new tricky problems.)
Thank you for your patience!