### PR TITLE
Feature/portamento

### DIFF
--- a/.github/workflows/project-pipeline.yml
+++ b/.github/workflows/project-pipeline.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Install Dexed Dependencies
       if: runner.os == 'Linux'
       run: |
-        sudo apt-get update && sudo apt install libasound2-dev libx11-dev libxinerama-dev libxext-dev libfreetype6-dev libwebkit2gtk-4.0-dev libglu1-mesa-dev ccache xvfb libjack-dev
+        sudo apt-get update && sudo apt install libasound2-dev libx11-dev libxinerama-dev libxext-dev libfreetype6-dev libwebkit2gtk-4.1-dev libglu1-mesa-dev ccache xvfb libjack-dev
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 10
         sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 10
 

--- a/.github/workflows/project-pipeline.yml
+++ b/.github/workflows/project-pipeline.yml
@@ -17,8 +17,8 @@ jobs:
       if: runner.os == 'Linux'
       run: |
         sudo apt-get update && sudo apt install libasound2-dev libx11-dev libxinerama-dev libxext-dev libfreetype6-dev libwebkit2gtk-4.1-dev libglu1-mesa-dev ccache xvfb libjack-dev
-        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 10
-        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 10
+        # sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 10
+        # sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 10
 
     - uses: actions/checkout@v4
       with:

--- a/Dexed.jucer
+++ b/Dexed.jucer
@@ -9,7 +9,7 @@
               pluginEditorRequiresKeys="0" pluginAUExportPrefix="DexedAU" pluginRTASCategory=""
               aaxIdentifier="com.yourcompany.Dexed" pluginAAXCategory="2" companyName="Digital Suburban"
               buildVST3="1" buildRTAS="0" buildAAX="0" pluginManufacturerEmail="support@yourcompany.com"
-              buildAUv3="0" pluginIsMidiEffectPlugin="0" displaySplashScreen="0"
+              buildAUv3="0" pluginIsMidiEffectPlugin="0" displaySplashScreen="1"
               reportAppUsage="0" splashScreenColour="Dark" buildStandalone="1"
               enableIAA="0" cppLanguageStandard="latest" companyCopyright="Digital Suburban"
               pluginFormats="buildAU,buildStandalone,buildVST3" pluginCharacteristicsValue="pluginIsSynth,pluginWantsMidiIn,pluginProducesMidiOut"
@@ -177,9 +177,11 @@
                vst3Folder="libs/vst3sdk" extraCompilerFlags="-I../../libs/tuning-library/include -I../../libs/MTS-ESP/Client -Wno-macro-redefined -Wno-deprecated-declarations -Wno-shorten-64-to-32 -DJUCE_MODAL_LOOPS_PERMITTED=1">
       <CONFIGURATIONS>
         <CONFIGURATION name="Debug" isDebug="1" optimisation="1" targetName="Dexed"
-                       osxCompatibility="10.10 SDK" osxArchitecture="Native" enablePluginBinaryCopyStep="1"/>
+                       osxCompatibility="10.10 SDK" osxArchitecture="Native" enablePluginBinaryCopyStep="1"
+                       macOSDeploymentTarget="10.10"/>
         <CONFIGURATION name="Release" isDebug="0" optimisation="3" targetName="Dexed"
-                       osxSDK="10.10 SDK" osxCompatibility="10.9 SDK" enablePluginBinaryCopyStep="1"/>
+                       osxSDK="10.10 SDK" osxCompatibility="10.9 SDK" enablePluginBinaryCopyStep="1"
+                       macOSBaseSDK="10.10" macOSDeploymentTarget="10.9"/>
       </CONFIGURATIONS>
       <MODULEPATHS>
         <MODULEPATH id="juce_gui_extra" path="./assets/JUCE/modules"/>
@@ -227,8 +229,8 @@
       </MODULEPATHS>
     </VS2017>
     <VS2019 targetFolder="Builds/VisualStudio2019" IPPLibrary="Parallel_Static"
-            extraCompilerFlags="/I../../libs/tuning-library/include -I../../libs/MTS-ESP/Client -DJUCE_MODAL_LOOPS_PERMITTED=1" smallIcon="SpSpb4"
-            bigIcon="SpSpb4">
+            extraCompilerFlags="/I../../libs/tuning-library/include -I../../libs/MTS-ESP/Client -DJUCE_MODAL_LOOPS_PERMITTED=1"
+            smallIcon="SpSpb4" bigIcon="SpSpb4">
       <CONFIGURATIONS>
         <CONFIGURATION name="Debug" winWarningLevel="3" generateManifest="1" winArchitecture="x64"
                        debugInformationFormat="ProgramDatabase" enablePluginBinaryCopyStep="0"

--- a/README.md
+++ b/README.md
@@ -162,6 +162,6 @@ Then you crate the cmake build files that are will be created in the build direc
 ~/dexed/build $ cmake --build .
 ```
 
-If you get missing header compilation errors, be sure to check the [known Linux dependencies](https://github.com/asb2m10/dexed/wiki/Linux-builds-dependencies) based on your distribution for Linux.
+If you get missing header compilation errors, be sure to check the [known Linux dependencies](https://github.com/asb2m10/dexed/wiki/Linux-build-dependencies) based on your distribution for Linux.
 
 Binaries will be found in `~/dexed/build/Source/Dexed_artefacts/*`

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ Dexed Forks
 
 Changelog
 ---------
+#### Version 0.9.9
+* Glissendo (portamento) implementation. Thanks @jpcima
+
 #### Version 0.9.8
 * Accessibility implementation (including [keyboard shortcuts](https://github.com/asb2m10/dexed/blob/master/Documentation/Keybindings.md))
 * UI component refresh

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Dexed - FM Plugin Synth
 
 Please see [Dexed User Website](https://asb2m10.github.io/dexed) for user and download information.
 
-Dexed is a multi platform, multi format plugin synth that is closely modeled on the Yamaha DX7.
+Dexed is a multi-platform, multi format plugin synth that is closely modeled on the Yamaha DX7.
 Under the hood it uses [music-synthesizer-for-android](https://github.com/google/music-synthesizer-for-android)
 for the synth engine and [JUCE](https://www.juce.com) as an application/plugin wrapper.
 
@@ -13,12 +13,12 @@ goes beyond the DX7 should and will be a fork of this project. This is to keep t
 the original machine.
 
 Dexed is licensed on the GPL v3. The msfa component (acronym for music synthesizer for android, see msfa
-in the source folder) stays on the Apache 2.0 license to able to collaborate between projects.
+in the source folder) stays on the Apache 2.0 license to be able to collaborate between projects.
 
 Donation
 --------
-As a maintainer of this 10 year old project, donations are welcomed. This also applies for the Apple users 
-to cover for the notarization of this software in the comming years. Thank you!
+As a maintainer of this 10-year-old project, donations are welcomed. This also applies for the Apple users 
+to cover for the notarization of this software in the coming years. Thank you!
 
 https://www.paypal.com/paypalme/asb2m10
 
@@ -30,7 +30,7 @@ Dexed Forks
 Changelog
 ---------
 #### Version 0.9.9
-* Glissendo (portamento) implementation. Thanks @jpcima
+* Partial portamento implementation. Thanks @jpcima
 
 #### Version 0.9.8
 * Accessibility implementation (including [keyboard shortcuts](https://github.com/asb2m10/dexed/blob/master/Documentation/Keybindings.md))
@@ -55,7 +55,7 @@ Changelog
 * Fix hang notes on program changes
 
 #### Version 0.9.5
-* Added support for SCL/KBM microtuning
+* Added support for SCL/KBM micro tuning
 * Added initial support for MPE performance
 * Upgraded build system to use JUCE 6.0 and build from locally acquired JUCE
 * A Collection of small UI changes, including higher contrast GUI assets, better sub-window management, 
@@ -134,7 +134,6 @@ TODO - Dexed
 
 TODO - msfa
 -----------
-* Portamento implementation
 * Better Amplitude Modulation
 * Accurate live operator level envelope updates
 

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -68,6 +68,7 @@ target_sources(${BaseTargetName} PRIVATE
         msfa/pitchenv.cc
         msfa/sin.cc
         msfa/tuning.cc
+        msfa/porta.cpp
 
     # until MTS-ESP has is own cmake project
     ../libs/MTS-ESP/Client/libMTSClient.cpp

--- a/Source/GlobalEditor.cpp
+++ b/Source/GlobalEditor.cpp
@@ -133,7 +133,7 @@ GlobalEditor::GlobalEditor ()
     //[Constructor_pre] You can add your own custom stuff here..
     //[/Constructor_pre]
 
-    lfoSpeed.reset (new juce::Slider ("lfoSpeed"));
+    lfoSpeed.reset (new DXSlider ("lfoSpeed"));
     addAndMakeVisible (lfoSpeed.get());
     lfoSpeed->setExplicitFocusOrder (14);
     lfoSpeed->setRange (0, 99, 1);
@@ -143,7 +143,7 @@ GlobalEditor::GlobalEditor ()
 
     lfoSpeed->setBounds (564, 50, 34, 34);
 
-    lfoAmDepth.reset (new juce::Slider ("lfoAmDepth"));
+    lfoAmDepth.reset (new DXSlider ("lfoAmDepth"));
     addAndMakeVisible (lfoAmDepth.get());
     lfoAmDepth->setExplicitFocusOrder (19);
     lfoAmDepth->setRange (0, 99, 1);
@@ -153,7 +153,7 @@ GlobalEditor::GlobalEditor ()
 
     lfoAmDepth->setBounds (686, 50, 34, 34);
 
-    lfoPitchDepth.reset (new juce::Slider ("lfoPitchDepth"));
+    lfoPitchDepth.reset (new DXSlider ("lfoPitchDepth"));
     addAndMakeVisible (lfoPitchDepth.get());
     lfoPitchDepth->setExplicitFocusOrder (18);
     lfoPitchDepth->setRange (0, 99, 1);
@@ -163,7 +163,7 @@ GlobalEditor::GlobalEditor ()
 
     lfoPitchDepth->setBounds (646, 50, 34, 34);
 
-    lfoDelay.reset (new juce::Slider ("lfoDelay"));
+    lfoDelay.reset (new DXSlider ("lfoDelay"));
     addAndMakeVisible (lfoDelay.get());
     lfoDelay->setExplicitFocusOrder (15);
     lfoDelay->setRange (0, 99, 1);
@@ -173,7 +173,7 @@ GlobalEditor::GlobalEditor ()
 
     lfoDelay->setBounds (603, 50, 34, 34);
 
-    cutoff.reset (new juce::Slider ("cutoff"));
+    cutoff.reset (new DXSlider ("cutoff"));
     addAndMakeVisible (cutoff.get());
     cutoff->setExplicitFocusOrder (6);
     cutoff->setRange (0, 1, 0);
@@ -183,7 +183,7 @@ GlobalEditor::GlobalEditor ()
 
     cutoff->setBounds (234, 9, 34, 34);
 
-    reso.reset (new juce::Slider ("reso"));
+    reso.reset (new DXSlider ("reso"));
     addAndMakeVisible (reso.get());
     reso->setExplicitFocusOrder (7);
     reso->setRange (0, 1, 0);
@@ -193,7 +193,7 @@ GlobalEditor::GlobalEditor ()
 
     reso->setBounds (278, 9, 34, 34);
 
-    pitchRate2.reset (new juce::Slider ("pitchRate2"));
+    pitchRate2.reset (new DXSlider ("pitchRate2"));
     addAndMakeVisible (pitchRate2.get());
     pitchRate2->setExplicitFocusOrder (24);
     pitchRate2->setRange (0, 99, 1);
@@ -203,7 +203,7 @@ GlobalEditor::GlobalEditor ()
 
     pitchRate2->setBounds (767, 96, 34, 34);
 
-    pitchRate3.reset (new juce::Slider ("pitchRate3"));
+    pitchRate3.reset (new DXSlider ("pitchRate3"));
     addAndMakeVisible (pitchRate3.get());
     pitchRate3->setExplicitFocusOrder (26);
     pitchRate3->setRange (0, 99, 1);
@@ -213,7 +213,7 @@ GlobalEditor::GlobalEditor ()
 
     pitchRate3->setBounds (795, 96, 35, 34);
 
-    pitchRate4.reset (new juce::Slider ("pitchRate4"));
+    pitchRate4.reset (new DXSlider ("pitchRate4"));
     addAndMakeVisible (pitchRate4.get());
     pitchRate4->setExplicitFocusOrder (28);
     pitchRate4->setRange (0, 99, 1);
@@ -223,7 +223,7 @@ GlobalEditor::GlobalEditor ()
 
     pitchRate4->setBounds (823, 96, 34, 34);
 
-    pitchRate1.reset (new juce::Slider ("pitchRate1"));
+    pitchRate1.reset (new DXSlider ("pitchRate1"));
     addAndMakeVisible (pitchRate1.get());
     pitchRate1->setExplicitFocusOrder (22);
     pitchRate1->setRange (0, 99, 1);
@@ -233,7 +233,7 @@ GlobalEditor::GlobalEditor ()
 
     pitchRate1->setBounds (739, 96, 34, 34);
 
-    pitchLevel2.reset (new juce::Slider ("pitchLevel2"));
+    pitchLevel2.reset (new DXSlider ("pitchLevel2"));
     addAndMakeVisible (pitchLevel2.get());
     pitchLevel2->setExplicitFocusOrder (23);
     pitchLevel2->setRange (0, 99, 1);
@@ -243,7 +243,7 @@ GlobalEditor::GlobalEditor ()
 
     pitchLevel2->setBounds (767, 57, 34, 34);
 
-    pitchLevel3.reset (new juce::Slider ("pitchLevel3"));
+    pitchLevel3.reset (new DXSlider ("pitchLevel3"));
     addAndMakeVisible (pitchLevel3.get());
     pitchLevel3->setExplicitFocusOrder (25);
     pitchLevel3->setRange (0, 99, 1);
@@ -253,7 +253,7 @@ GlobalEditor::GlobalEditor ()
 
     pitchLevel3->setBounds (795, 56, 34, 34);
 
-    pitchLevel4.reset (new juce::Slider ("pitchLevel4"));
+    pitchLevel4.reset (new DXSlider ("pitchLevel4"));
     addAndMakeVisible (pitchLevel4.get());
     pitchLevel4->setExplicitFocusOrder (27);
     pitchLevel4->setRange (0, 99, 1);
@@ -263,7 +263,7 @@ GlobalEditor::GlobalEditor ()
 
     pitchLevel4->setBounds (823, 56, 34, 34);
 
-    pitchLevel1.reset (new juce::Slider ("pitchLevel1"));
+    pitchLevel1.reset (new DXSlider ("pitchLevel1"));
     addAndMakeVisible (pitchLevel1.get());
     pitchLevel1->setExplicitFocusOrder (21);
     pitchLevel1->setRange (0, 99, 1);
@@ -273,7 +273,7 @@ GlobalEditor::GlobalEditor ()
 
     pitchLevel1->setBounds (739, 57, 34, 34);
 
-    transpose.reset (new juce::Slider ("transpose"));
+    transpose.reset (new DXSlider ("transpose"));
     addAndMakeVisible (transpose.get());
     transpose->setExplicitFocusOrder (9);
     transpose->setRange (0, 48, 1);
@@ -291,7 +291,7 @@ GlobalEditor::GlobalEditor ()
 
     oscSync->setBounds (650, 96, 48, 26);
 
-    pitchModSens.reset (new juce::Slider ("pitchModSens"));
+    pitchModSens.reset (new DXSlider ("pitchModSens"));
     addAndMakeVisible (pitchModSens.get());
     pitchModSens->setExplicitFocusOrder (17);
     pitchModSens->setRange (0, 7, 1);
@@ -321,7 +321,7 @@ GlobalEditor::GlobalEditor ()
 
     algoDisplay->setBounds (335, 30, 152, 91);
 
-    feedback.reset (new juce::Slider ("feedback"));
+    feedback.reset (new DXSlider ("feedback"));
     addAndMakeVisible (feedback.get());
     feedback->setExplicitFocusOrder (12);
     feedback->setRange (0, 7, 1);
@@ -331,7 +331,7 @@ GlobalEditor::GlobalEditor ()
 
     feedback->setBounds (501, 81, 34, 34);
 
-    algo.reset (new juce::Slider ("algo"));
+    algo.reset (new DXSlider ("algo"));
     addAndMakeVisible (algo.get());
     algo->setExplicitFocusOrder (11);
     algo->setRange (1, 32, 1);
@@ -347,7 +347,7 @@ GlobalEditor::GlobalEditor ()
 
     lcdDisplay->setBounds (6, 87, 140, 13);
 
-    output.reset (new juce::Slider ("output"));
+    output.reset (new DXSlider ("output"));
     addAndMakeVisible (output.get());
     output->setExplicitFocusOrder (8);
     output->setRange (0, 1, 0);
@@ -427,7 +427,7 @@ GlobalEditor::GlobalEditor ()
                             juce::Image(), 1.000f, juce::Colour (0x00000000));
     aboutButton->setBounds (8, 11, 135, 46);
 
-    tune.reset (new juce::Slider ("tune"));
+    tune.reset (new DXSlider ("tune"));
     addAndMakeVisible (tune.get());
     tune->setExplicitFocusOrder (5);
     tune->setRange (0, 1, 0);

--- a/Source/GlobalEditor.cpp
+++ b/Source/GlobalEditor.cpp
@@ -7,7 +7,7 @@
   the "//[xyz]" and "//[/xyz]" sections will be retained when the file is loaded
   and re-saved.
 
-  Created with Projucer version: 7.0.9
+  Created with Projucer version: 7.0.11
 
   ------------------------------------------------------------------------------
 
@@ -133,7 +133,7 @@ GlobalEditor::GlobalEditor ()
     //[Constructor_pre] You can add your own custom stuff here..
     //[/Constructor_pre]
 
-    lfoSpeed.reset (new DXSlider ("lfoSpeed"));
+    lfoSpeed.reset (new juce::Slider ("lfoSpeed"));
     addAndMakeVisible (lfoSpeed.get());
     lfoSpeed->setExplicitFocusOrder (14);
     lfoSpeed->setRange (0, 99, 1);
@@ -143,7 +143,7 @@ GlobalEditor::GlobalEditor ()
 
     lfoSpeed->setBounds (564, 50, 34, 34);
 
-    lfoAmDepth.reset (new DXSlider ("lfoAmDepth"));
+    lfoAmDepth.reset (new juce::Slider ("lfoAmDepth"));
     addAndMakeVisible (lfoAmDepth.get());
     lfoAmDepth->setExplicitFocusOrder (19);
     lfoAmDepth->setRange (0, 99, 1);
@@ -153,7 +153,7 @@ GlobalEditor::GlobalEditor ()
 
     lfoAmDepth->setBounds (686, 50, 34, 34);
 
-    lfoPitchDepth.reset (new DXSlider ("lfoPitchDepth"));
+    lfoPitchDepth.reset (new juce::Slider ("lfoPitchDepth"));
     addAndMakeVisible (lfoPitchDepth.get());
     lfoPitchDepth->setExplicitFocusOrder (18);
     lfoPitchDepth->setRange (0, 99, 1);
@@ -163,7 +163,7 @@ GlobalEditor::GlobalEditor ()
 
     lfoPitchDepth->setBounds (646, 50, 34, 34);
 
-    lfoDelay.reset (new DXSlider ("lfoDelay"));
+    lfoDelay.reset (new juce::Slider ("lfoDelay"));
     addAndMakeVisible (lfoDelay.get());
     lfoDelay->setExplicitFocusOrder (15);
     lfoDelay->setRange (0, 99, 1);
@@ -173,7 +173,7 @@ GlobalEditor::GlobalEditor ()
 
     lfoDelay->setBounds (603, 50, 34, 34);
 
-    cutoff.reset (new DXSlider ("cutoff"));
+    cutoff.reset (new juce::Slider ("cutoff"));
     addAndMakeVisible (cutoff.get());
     cutoff->setExplicitFocusOrder (6);
     cutoff->setRange (0, 1, 0);
@@ -183,7 +183,7 @@ GlobalEditor::GlobalEditor ()
 
     cutoff->setBounds (234, 9, 34, 34);
 
-    reso.reset (new DXSlider ("reso"));
+    reso.reset (new juce::Slider ("reso"));
     addAndMakeVisible (reso.get());
     reso->setExplicitFocusOrder (7);
     reso->setRange (0, 1, 0);
@@ -193,7 +193,7 @@ GlobalEditor::GlobalEditor ()
 
     reso->setBounds (278, 9, 34, 34);
 
-    pitchRate2.reset (new DXSlider ("pitchRate2"));
+    pitchRate2.reset (new juce::Slider ("pitchRate2"));
     addAndMakeVisible (pitchRate2.get());
     pitchRate2->setExplicitFocusOrder (24);
     pitchRate2->setRange (0, 99, 1);
@@ -203,7 +203,7 @@ GlobalEditor::GlobalEditor ()
 
     pitchRate2->setBounds (767, 96, 34, 34);
 
-    pitchRate3.reset (new DXSlider ("pitchRate3"));
+    pitchRate3.reset (new juce::Slider ("pitchRate3"));
     addAndMakeVisible (pitchRate3.get());
     pitchRate3->setExplicitFocusOrder (26);
     pitchRate3->setRange (0, 99, 1);
@@ -213,7 +213,7 @@ GlobalEditor::GlobalEditor ()
 
     pitchRate3->setBounds (795, 96, 35, 34);
 
-    pitchRate4.reset (new DXSlider ("pitchRate4"));
+    pitchRate4.reset (new juce::Slider ("pitchRate4"));
     addAndMakeVisible (pitchRate4.get());
     pitchRate4->setExplicitFocusOrder (28);
     pitchRate4->setRange (0, 99, 1);
@@ -223,7 +223,7 @@ GlobalEditor::GlobalEditor ()
 
     pitchRate4->setBounds (823, 96, 34, 34);
 
-    pitchRate1.reset (new DXSlider ("pitchRate1"));
+    pitchRate1.reset (new juce::Slider ("pitchRate1"));
     addAndMakeVisible (pitchRate1.get());
     pitchRate1->setExplicitFocusOrder (22);
     pitchRate1->setRange (0, 99, 1);
@@ -233,7 +233,7 @@ GlobalEditor::GlobalEditor ()
 
     pitchRate1->setBounds (739, 96, 34, 34);
 
-    pitchLevel2.reset (new DXSlider ("pitchLevel2"));
+    pitchLevel2.reset (new juce::Slider ("pitchLevel2"));
     addAndMakeVisible (pitchLevel2.get());
     pitchLevel2->setExplicitFocusOrder (23);
     pitchLevel2->setRange (0, 99, 1);
@@ -243,7 +243,7 @@ GlobalEditor::GlobalEditor ()
 
     pitchLevel2->setBounds (767, 57, 34, 34);
 
-    pitchLevel3.reset (new DXSlider ("pitchLevel3"));
+    pitchLevel3.reset (new juce::Slider ("pitchLevel3"));
     addAndMakeVisible (pitchLevel3.get());
     pitchLevel3->setExplicitFocusOrder (25);
     pitchLevel3->setRange (0, 99, 1);
@@ -253,7 +253,7 @@ GlobalEditor::GlobalEditor ()
 
     pitchLevel3->setBounds (795, 56, 34, 34);
 
-    pitchLevel4.reset (new DXSlider ("pitchLevel4"));
+    pitchLevel4.reset (new juce::Slider ("pitchLevel4"));
     addAndMakeVisible (pitchLevel4.get());
     pitchLevel4->setExplicitFocusOrder (27);
     pitchLevel4->setRange (0, 99, 1);
@@ -263,7 +263,7 @@ GlobalEditor::GlobalEditor ()
 
     pitchLevel4->setBounds (823, 56, 34, 34);
 
-    pitchLevel1.reset (new DXSlider ("pitchLevel1"));
+    pitchLevel1.reset (new juce::Slider ("pitchLevel1"));
     addAndMakeVisible (pitchLevel1.get());
     pitchLevel1->setExplicitFocusOrder (21);
     pitchLevel1->setRange (0, 99, 1);
@@ -273,7 +273,7 @@ GlobalEditor::GlobalEditor ()
 
     pitchLevel1->setBounds (739, 57, 34, 34);
 
-    transpose.reset (new DXSlider ("transpose"));
+    transpose.reset (new juce::Slider ("transpose"));
     addAndMakeVisible (transpose.get());
     transpose->setExplicitFocusOrder (9);
     transpose->setRange (0, 48, 1);
@@ -291,7 +291,7 @@ GlobalEditor::GlobalEditor ()
 
     oscSync->setBounds (650, 96, 48, 26);
 
-    pitchModSens.reset (new DXSlider ("pitchModSens"));
+    pitchModSens.reset (new juce::Slider ("pitchModSens"));
     addAndMakeVisible (pitchModSens.get());
     pitchModSens->setExplicitFocusOrder (17);
     pitchModSens->setRange (0, 7, 1);
@@ -321,7 +321,7 @@ GlobalEditor::GlobalEditor ()
 
     algoDisplay->setBounds (335, 30, 152, 91);
 
-    feedback.reset (new DXSlider ("feedback"));
+    feedback.reset (new juce::Slider ("feedback"));
     addAndMakeVisible (feedback.get());
     feedback->setExplicitFocusOrder (12);
     feedback->setRange (0, 7, 1);
@@ -331,7 +331,7 @@ GlobalEditor::GlobalEditor ()
 
     feedback->setBounds (501, 81, 34, 34);
 
-    algo.reset (new DXSlider ("algo"));
+    algo.reset (new juce::Slider ("algo"));
     addAndMakeVisible (algo.get());
     algo->setExplicitFocusOrder (11);
     algo->setRange (1, 32, 1);
@@ -347,7 +347,7 @@ GlobalEditor::GlobalEditor ()
 
     lcdDisplay->setBounds (6, 87, 140, 13);
 
-    output.reset (new DXSlider ("output"));
+    output.reset (new juce::Slider ("output"));
     addAndMakeVisible (output.get());
     output->setExplicitFocusOrder (8);
     output->setRange (0, 1, 0);
@@ -357,7 +357,7 @@ GlobalEditor::GlobalEditor ()
 
     output->setBounds (157, 60, 34, 34);
 
-    vuOutput.reset (new VuMeterOutput ());
+    vuOutput.reset (new VuMeterOutput());
     addAndMakeVisible (vuOutput.get());
     vuOutput->setName ("vuOutput");
 
@@ -427,7 +427,7 @@ GlobalEditor::GlobalEditor ()
                             juce::Image(), 1.000f, juce::Colour (0x00000000));
     aboutButton->setBounds (8, 11, 135, 46);
 
-    tune.reset (new DXSlider ("tune"));
+    tune.reset (new juce::Slider ("tune"));
     addAndMakeVisible (tune.get());
     tune->setExplicitFocusOrder (5);
     tune->setRange (0, 1, 0);

--- a/Source/GlobalEditor.h
+++ b/Source/GlobalEditor.h
@@ -7,7 +7,7 @@
   the "//[xyz]" and "//[/xyz]" sections will be retained when the file is loaded
   and re-saved.
 
-  Created with Projucer version: 7.0.9
+  Created with Projucer version: 7.0.11
 
   ------------------------------------------------------------------------------
 
@@ -20,7 +20,6 @@
 #pragma once
 
 //[Headers]     -- You can add your own extra header files here --
-#include "JuceHeader.h"
 #include "PluginProcessor.h"
 #include "DXComponents.h"
 #include "AlgoDisplay.h"

--- a/Source/ParamDialog.cpp
+++ b/Source/ParamDialog.cpp
@@ -293,7 +293,7 @@ ParamDialog::ParamDialog ()
     mpePBRange->setTextBoxStyle (juce::Slider::TextBoxLeft, false, 80, 20);
     mpePBRange->addListener (this);
 
-    mpePBRange->setBounds (616, 323, 72, 24);
+    mpePBRange->setBounds (616, 319, 72, 24);
 
     mpeEnabled.reset (new LightedToggleButton ("mpeEnabled"));
     addAndMakeVisible (mpeEnabled.get());
@@ -340,15 +340,15 @@ ParamDialog::ParamDialog ()
 
     scalingFactor->setBounds (236, 136, 90, 24);
 
-    glissendo.reset (new LightedToggleButton ("glissendo"));
-    addAndMakeVisible (glissendo.get());
-    glissendo->setExplicitFocusOrder (30);
-    glissendo->setButtonText (juce::String());
-    glissendo->setTooltip ("Enable or disable glissando effect.");
-    glissendo->addListener (this);
-    glissendo->setToggleState (true, juce::dontSendNotification);
+    glissando.reset (new LightedToggleButton ("glissando"));
+    addAndMakeVisible (glissando.get());
+    glissando->setExplicitFocusOrder (30);
+    glissando->setButtonText (juce::String());
+    glissando->setTooltip ("Enable or disable glissando effect.");
+    glissando->addListener (this);
+    glissando->setToggleState (true, juce::dontSendNotification);
 
-    glissendo->setBounds (576, 272, 56, 30);
+    glissando->setBounds (576, 276, 56, 30);
 
     portamentoTm.reset (new juce::Slider ("portamentoTm"));
     addAndMakeVisible (portamentoTm.get());
@@ -498,7 +498,7 @@ ParamDialog::~ParamDialog()
     transposeHelp = nullptr;
     pitchRangeUp = nullptr;
     scalingFactor = nullptr;
-    glissendo = nullptr;
+    glissando = nullptr;
     portamentoTm = nullptr;
 
 
@@ -540,7 +540,7 @@ void ParamDialog::paint (juce::Graphics& g)
     }
 
     {
-        int x = 24, y = 319, width = 245, height = 23;
+        int x = 20, y = 319, width = 245, height = 23;
         juce::String text (TRANS ("DX7 Channel"));
         juce::Colour fillColour = juce::Colours::white;
         //[UserPaintCustomArguments] Customize the painting arguments here..
@@ -729,7 +729,7 @@ void ParamDialog::paint (juce::Graphics& g)
     }
 
     {
-        int x = 368, y = 322, width = 276, height = 27;
+        int x = 368, y = 318, width = 276, height = 27;
         juce::String text (TRANS ("MPE"));
         juce::Colour fillColour = juce::Colours::white;
         //[UserPaintCustomArguments] Customize the painting arguments here..
@@ -741,7 +741,7 @@ void ParamDialog::paint (juce::Graphics& g)
     }
 
     {
-        int x = 528, y = 322, width = 119, height = 27;
+        int x = 528, y = 318, width = 119, height = 27;
         juce::String text (TRANS ("Bend Range"));
         juce::Colour fillColour = juce::Colours::white;
         //[UserPaintCustomArguments] Customize the painting arguments here..
@@ -825,15 +825,15 @@ void ParamDialog::paint (juce::Graphics& g)
     }
 
     {
-        int x = 612, y = 274, width = 75, height = 27;
-        juce::String text (TRANS ("Glissendo"));
+        int x = 628, y = 274, width = 75, height = 27;
+        juce::String text (TRANS ("Glissando"));
         juce::Colour fillColour = juce::Colours::white;
         //[UserPaintCustomArguments] Customize the painting arguments here..
         //[/UserPaintCustomArguments]
         g.setColour (fillColour);
         g.setFont (juce::Font (15.00f, juce::Font::plain).withTypefaceStyle ("Regular"));
         g.drawText (text, x, y, width, height,
-                    juce::Justification::centredRight, true);
+                    juce::Justification::centredLeft, true);
     }
 
     //[UserPaint] Add your own custom painting code here..
@@ -1102,10 +1102,10 @@ With the switch in the 12 (unlighted) position, transposition stays with the key
 
         //[/UserButtonCode_transposeHelp]
     }
-    else if (buttonThatWasClicked == glissendo.get())
+    else if (buttonThatWasClicked == glissando.get())
     {
-        //[UserButtonCode_glissendo] -- add your button handler code here..
-        //[/UserButtonCode_glissendo]
+        //[UserButtonCode_glissando] -- add your button handler code here..
+        //[/UserButtonCode_glissando]
     }
 
     //[UserbuttonClicked_Post]
@@ -1153,7 +1153,7 @@ void ParamDialog::setDialogValues(Controllers &c, SysexComm &mgr, int reso, bool
     mpePBRange->setValue(c.mpePitchBendRange, dontSendNotification);
 
     portamentoTm->setValue(c.portamento_cc * 100.0f / 127.0f); // Convert from 0-127 range to 0-100%
-    glissendo->setToggleState(c.portamento_gliss_cc, dontSendNotification);
+    glissando->setToggleState(c.portamento_gliss_cc, dontSendNotification);
 
     StringArray inputs = MidiInput::getDevices();
     int idx = inputs.indexOf(mgr.getInput());
@@ -1220,7 +1220,7 @@ bool ParamDialog::getDialogValues(Controllers &c, SysexComm &mgr, int *reso, boo
 
     c.portamento_cc = portamentoTm->getValue() * 127.0f / 100.0f; // Convert to 0-127 range
     c.portamento_enable_cc = c.portamento_cc > 0;
-    c.portamento_gliss_cc = glissendo->getToggleState();
+    c.portamento_gliss_cc = glissando->getToggleState();
 
     c.refresh();
 
@@ -1366,9 +1366,9 @@ BEGIN_JUCER_METADATA
     <TEXT pos="371 277 184 23" fill="solid: ffffffff" hasStroke="0" text="Portamento Rate"
           fontname="Default font" fontsize="15.0" kerning="0.0" bold="0"
           italic="0" justification="33"/>
-    <TEXT pos="612 274 75 27" fill="solid: ffffffff" hasStroke="0" text="Glissendo"
+    <TEXT pos="628 274 75 27" fill="solid: ffffffff" hasStroke="0" text="Glissando"
           fontname="Default font" fontsize="15.0" kerning="0.0" bold="0"
-          italic="0" justification="34"/>
+          italic="0" justification="33"/>
   </BACKGROUND>
   <SLIDER name="pitchRangeDn" id="7409be5a8dfaa91" memberName="pitchRangeDn"
           virtualName="" explicitFocusOrder="2" pos="264 16 72 24" min="0.0"
@@ -1495,7 +1495,7 @@ BEGIN_JUCER_METADATA
             virtualName="" explicitFocusOrder="5" pos="236 136 90 24" editable="0"
             layout="33" items="100 %&#10;125 %&#10;150 %&#10;200 %&#10;300 %&#10;400 %"
             textWhenNonSelected="" textWhenNoItems="(no choices)"/>
-  <TOGGLEBUTTON name="glissendo" id="f531397d4cf195a6" memberName="glissendo"
+  <TOGGLEBUTTON name="glissando" id="f531397d4cf195a6" memberName="glissando"
                 virtualName="LightedToggleButton" explicitFocusOrder="30" pos="576 272 56 30"
                 buttonText="" connectedEdges="0" needsCallback="1" radioGroupId="0"
                 state="1"/>

--- a/Source/ParamDialog.cpp
+++ b/Source/ParamDialog.cpp
@@ -1150,6 +1150,9 @@ void ParamDialog::setDialogValues(Controllers &c, SysexComm &mgr, int reso, bool
     mpeEnabled->setToggleState(c.mpeEnabled, dontSendNotification);
     mpePBRange->setValue(c.mpePitchBendRange, dontSendNotification);
 
+    portamentoTm->setValue(c.portamento_cc);
+    glissendo->setToggleState(c.portamento_gliss_cc, dontSendNotification);
+
     StringArray inputs = MidiInput::getDevices();
     int idx = inputs.indexOf(mgr.getInput());
     idx = idx == -1 ? 0 : idx + 1;
@@ -1187,6 +1190,7 @@ bool ParamDialog::getDialogValues(Controllers &c, SysexComm &mgr, int *reso, boo
     c.values_[kControllerPitchRangeUp] = pitchRangeUp->getValue();
     c.values_[kControllerPitchRangeDn] = pitchRangeDn->getValue();
     c.values_[kControllerPitchStep] = pitchStep->getValue();
+    c.values_[kControllerPortamentoGlissando] = portamentoTm->getValue();
 
     c.wheel.range = whlRange->getValue();
     c.wheel.pitch = whlPitch->getToggleState();
@@ -1212,6 +1216,10 @@ bool ParamDialog::getDialogValues(Controllers &c, SysexComm &mgr, int *reso, boo
 
     c.mpeEnabled = mpeEnabled->getToggleState();
     c.mpePitchBendRange = mpePBRange->getValue();
+
+    c.portamento_cc = portamentoTm->getValue();
+    c.portamento_enable_cc = c.portamento_cc > 0;
+    c.portamento_gliss_cc = glissendo->getToggleState();
 
     c.refresh();
 

--- a/Source/ParamDialog.cpp
+++ b/Source/ParamDialog.cpp
@@ -344,6 +344,7 @@ ParamDialog::ParamDialog ()
     addAndMakeVisible (glissendo.get());
     glissendo->setExplicitFocusOrder (30);
     glissendo->setButtonText (juce::String());
+    glissendo->setTooltip ("Enable or disable glissando effect.");
     glissendo->addListener (this);
     glissendo->setToggleState (true, juce::dontSendNotification);
 
@@ -354,6 +355,7 @@ ParamDialog::ParamDialog ()
     portamentoTm->setExplicitFocusOrder (22);
     portamentoTm->setRange (0, 99, 1);
     portamentoTm->setSliderStyle (juce::Slider::RotaryVerticalDrag);
+    portamentoTm->setTooltip ("Adjust the portamento time.");
     portamentoTm->setTextBoxStyle (juce::Slider::TextBoxLeft, false, 80, 20);
     portamentoTm->addListener (this);
 

--- a/Source/ParamDialog.cpp
+++ b/Source/ParamDialog.cpp
@@ -7,7 +7,7 @@
   the "//[xyz]" and "//[/xyz]" sections will be retained when the file is loaded
   and re-saved.
 
-  Created with Projucer version: 7.0.9
+  Created with Projucer version: 7.0.11
 
   ------------------------------------------------------------------------------
 
@@ -34,7 +34,7 @@ ParamDialog::ParamDialog ()
     //[Constructor_pre] You can add your own custom stuff here..
     //[/Constructor_pre]
 
-    pitchRangeDn.reset (new DXSlider ("pitchRangeDn"));
+    pitchRangeDn.reset (new juce::Slider ("pitchRangeDn"));
     addAndMakeVisible (pitchRangeDn.get());
     pitchRangeDn->setExplicitFocusOrder (2);
     pitchRangeDn->setRange (0, 48, 1);
@@ -44,7 +44,7 @@ ParamDialog::ParamDialog ()
 
     pitchRangeDn->setBounds (264, 16, 72, 24);
 
-    pitchStep.reset (new DXSlider ("pitchStep"));
+    pitchStep.reset (new juce::Slider ("pitchStep"));
     addAndMakeVisible (pitchStep.get());
     pitchStep->setExplicitFocusOrder (3);
     pitchStep->setRange (0, 12, 1);
@@ -76,7 +76,7 @@ ParamDialog::ParamDialog ()
 
     sysexOut->setBounds (104, 280, 224, 24);
 
-    sysexChl.reset (new DXSlider ("sysexChl"));
+    sysexChl.reset (new juce::Slider ("sysexChl"));
     addAndMakeVisible (sysexChl.get());
     sysexChl->setExplicitFocusOrder (9);
     sysexChl->setRange (1, 16, 1);
@@ -84,7 +84,7 @@ ParamDialog::ParamDialog ()
     sysexChl->setTextBoxStyle (juce::Slider::TextBoxLeft, false, 80, 20);
     sysexChl->addListener (this);
 
-    sysexChl->setBounds (264, 316, 72, 24);
+    sysexChl->setBounds (252, 320, 72, 24);
 
     engineReso.reset (new juce::ComboBox ("new combo box"));
     addAndMakeVisible (engineReso.get());
@@ -108,7 +108,7 @@ ParamDialog::ParamDialog ()
 
     showKeyboard->setBounds (264, 96, 56, 24);
 
-    whlRange.reset (new DXSlider ("whlRange"));
+    whlRange.reset (new juce::Slider ("whlRange"));
     addAndMakeVisible (whlRange.get());
     whlRange->setExplicitFocusOrder (10);
     whlRange->setRange (0, 99, 1);
@@ -118,7 +118,7 @@ ParamDialog::ParamDialog ()
 
     whlRange->setBounds (448, 16, 72, 24);
 
-    ftRange.reset (new DXSlider ("ftRange"));
+    ftRange.reset (new juce::Slider ("ftRange"));
     addAndMakeVisible (ftRange.get());
     ftRange->setExplicitFocusOrder (14);
     ftRange->setRange (0, 99, 1);
@@ -128,7 +128,7 @@ ParamDialog::ParamDialog ()
 
     ftRange->setBounds (448, 56, 72, 24);
 
-    brRange.reset (new DXSlider ("brRange"));
+    brRange.reset (new juce::Slider ("brRange"));
     addAndMakeVisible (brRange.get());
     brRange->setExplicitFocusOrder (18);
     brRange->setRange (0, 99, 1);
@@ -138,7 +138,7 @@ ParamDialog::ParamDialog ()
 
     brRange->setBounds (448, 96, 72, 24);
 
-    atRange.reset (new DXSlider ("atRange"));
+    atRange.reset (new juce::Slider ("atRange"));
     addAndMakeVisible (atRange.get());
     atRange->setExplicitFocusOrder (22);
     atRange->setRange (0, 99, 1);
@@ -283,9 +283,9 @@ ParamDialog::ParamDialog ()
     transposeScale->addListener (this);
     transposeScale->setToggleState (true, juce::dontSendNotification);
 
-    transposeScale->setBounds (592, 240, 56, 30);
+    transposeScale->setBounds (576, 240, 56, 30);
 
-    mpePBRange.reset (new DXSlider ("mpePBRange"));
+    mpePBRange.reset (new juce::Slider ("mpePBRange"));
     addAndMakeVisible (mpePBRange.get());
     mpePBRange->setExplicitFocusOrder (32);
     mpePBRange->setRange (0, 96, 1);
@@ -293,7 +293,7 @@ ParamDialog::ParamDialog ()
     mpePBRange->setTextBoxStyle (juce::Slider::TextBoxLeft, false, 80, 20);
     mpePBRange->addListener (this);
 
-    mpePBRange->setBounds (616, 291, 72, 24);
+    mpePBRange->setBounds (616, 323, 72, 24);
 
     mpeEnabled.reset (new LightedToggleButton ("mpeEnabled"));
     addAndMakeVisible (mpeEnabled.get());
@@ -301,7 +301,7 @@ ParamDialog::ParamDialog ()
     mpeEnabled->setButtonText (juce::String());
     mpeEnabled->addListener (this);
 
-    mpeEnabled->setBounds (448, 288, 56, 30);
+    mpeEnabled->setBounds (456, 320, 48, 30);
 
     transposeHelp.reset (new juce::ImageButton ("new button"));
     addAndMakeVisible (transposeHelp.get());
@@ -313,7 +313,7 @@ ParamDialog::ParamDialog ()
                               juce::Image(), 1.000f, juce::Colour (0x00000000));
     transposeHelp->setBounds (500, 245, 20, 20);
 
-    pitchRangeUp.reset (new DXSlider ("pitchRangeUp"));
+    pitchRangeUp.reset (new juce::Slider ("pitchRangeUp"));
     addAndMakeVisible (pitchRangeUp.get());
     pitchRangeUp->setExplicitFocusOrder (1);
     pitchRangeUp->setRange (0, 48, 1);
@@ -340,11 +340,30 @@ ParamDialog::ParamDialog ()
 
     scalingFactor->setBounds (236, 136, 90, 24);
 
+    glissendo.reset (new LightedToggleButton ("glissendo"));
+    addAndMakeVisible (glissendo.get());
+    glissendo->setExplicitFocusOrder (30);
+    glissendo->setButtonText (juce::String());
+    glissendo->addListener (this);
+    glissendo->setToggleState (true, juce::dontSendNotification);
+
+    glissendo->setBounds (576, 272, 56, 30);
+
+    portamentoTm.reset (new juce::Slider ("portamentoTm"));
+    addAndMakeVisible (portamentoTm.get());
+    portamentoTm->setExplicitFocusOrder (22);
+    portamentoTm->setRange (0, 99, 1);
+    portamentoTm->setSliderStyle (juce::Slider::RotaryVerticalDrag);
+    portamentoTm->setTextBoxStyle (juce::Slider::TextBoxLeft, false, 80, 20);
+    portamentoTm->addListener (this);
+
+    portamentoTm->setBounds (504, 276, 72, 24);
+
 
     //[UserPreSize]
     //[/UserPreSize]
 
-    setSize (710, 355);
+    setSize (710, 370);
 
 
     //[Constructor] You can add your own custom stuff here..
@@ -477,6 +496,8 @@ ParamDialog::~ParamDialog()
     transposeHelp = nullptr;
     pitchRangeUp = nullptr;
     scalingFactor = nullptr;
+    glissendo = nullptr;
+    portamentoTm = nullptr;
 
 
     //[Destructor]. You can add your own custom destruction code here..
@@ -517,7 +538,7 @@ void ParamDialog::paint (juce::Graphics& g)
     }
 
     {
-        int x = 20, y = 318, width = 245, height = 23;
+        int x = 24, y = 319, width = 245, height = 23;
         juce::String text (TRANS ("DX7 Channel"));
         juce::Colour fillColour = juce::Colours::white;
         //[UserPaintCustomArguments] Customize the painting arguments here..
@@ -571,7 +592,7 @@ void ParamDialog::paint (juce::Graphics& g)
     }
 
     {
-        int x = 352, y = 11, width = 1, height = 330;
+        int x = 352, y = 12, width = 1, height = 349;
         juce::Colour fillColour = juce::Colours::black;
         //[UserPaintCustomArguments] Customize the painting arguments here..
         //[/UserPaintCustomArguments]
@@ -664,7 +685,7 @@ void ParamDialog::paint (juce::Graphics& g)
     }
 
     {
-        int x = 371, y = 194, width = 325, height = 1;
+        int x = 376, y = 194, width = 325, height = 1;
         juce::Colour fillColour = juce::Colours::black;
         //[UserPaintCustomArguments] Customize the painting arguments here..
         //[/UserPaintCustomArguments]
@@ -697,7 +718,7 @@ void ParamDialog::paint (juce::Graphics& g)
     }
 
     {
-        int x = 368, y = 280, width = 328, height = 1;
+        int x = 368, y = 310, width = 328, height = 1;
         juce::Colour fillColour = juce::Colours::black;
         //[UserPaintCustomArguments] Customize the painting arguments here..
         //[/UserPaintCustomArguments]
@@ -706,7 +727,7 @@ void ParamDialog::paint (juce::Graphics& g)
     }
 
     {
-        int x = 371, y = 290, width = 276, height = 27;
+        int x = 368, y = 322, width = 276, height = 27;
         juce::String text (TRANS ("MPE"));
         juce::Colour fillColour = juce::Colours::white;
         //[UserPaintCustomArguments] Customize the painting arguments here..
@@ -718,7 +739,7 @@ void ParamDialog::paint (juce::Graphics& g)
     }
 
     {
-        int x = 528, y = 290, width = 119, height = 27;
+        int x = 528, y = 322, width = 119, height = 27;
         juce::String text (TRANS ("Bend Range"));
         juce::Colour fillColour = juce::Colours::white;
         //[UserPaintCustomArguments] Customize the painting arguments here..
@@ -730,7 +751,7 @@ void ParamDialog::paint (juce::Graphics& g)
     }
 
     {
-        int x = 555, y = 242, width = 37, height = 25;
+        int x = 548, y = 242, width = 37, height = 25;
         juce::String text (TRANS ("12"));
         juce::Colour fillColour = juce::Colours::white;
         //[UserPaintCustomArguments] Customize the painting arguments here..
@@ -742,7 +763,7 @@ void ParamDialog::paint (juce::Graphics& g)
     }
 
     {
-        int x = 659, y = 242, width = 45, height = 25;
+        int x = 628, y = 242, width = 45, height = 25;
         juce::String text (TRANS ("SCL"));
         juce::Colour fillColour = juce::Colours::white;
         //[UserPaintCustomArguments] Customize the painting arguments here..
@@ -787,6 +808,30 @@ void ParamDialog::paint (juce::Graphics& g)
         g.setFont (juce::Font (15.00f, juce::Font::plain).withTypefaceStyle ("Regular"));
         g.drawText (text, x, y, width, height,
                     juce::Justification::centredLeft, true);
+    }
+
+    {
+        int x = 371, y = 277, width = 184, height = 23;
+        juce::String text (TRANS ("Portamento Rate"));
+        juce::Colour fillColour = juce::Colours::white;
+        //[UserPaintCustomArguments] Customize the painting arguments here..
+        //[/UserPaintCustomArguments]
+        g.setColour (fillColour);
+        g.setFont (juce::Font (15.00f, juce::Font::plain).withTypefaceStyle ("Regular"));
+        g.drawText (text, x, y, width, height,
+                    juce::Justification::centredLeft, true);
+    }
+
+    {
+        int x = 612, y = 274, width = 75, height = 27;
+        juce::String text (TRANS ("Glissendo"));
+        juce::Colour fillColour = juce::Colours::white;
+        //[UserPaintCustomArguments] Customize the painting arguments here..
+        //[/UserPaintCustomArguments]
+        g.setColour (fillColour);
+        g.setFont (juce::Font (15.00f, juce::Font::plain).withTypefaceStyle ("Regular"));
+        g.drawText (text, x, y, width, height,
+                    juce::Justification::centredRight, true);
     }
 
     //[UserPaint] Add your own custom painting code here..
@@ -867,6 +912,11 @@ void ParamDialog::sliderValueChanged (juce::Slider* sliderThatWasMoved)
     {
         //[UserSliderCode_pitchRangeUp] -- add your slider handling code here..
         //[/UserSliderCode_pitchRangeUp]
+    }
+    else if (sliderThatWasMoved == portamentoTm.get())
+    {
+        //[UserSliderCode_portamentoTm] -- add your slider handling code here..
+        //[/UserSliderCode_portamentoTm]
     }
 
     //[UsersliderValueChanged_Post]
@@ -1050,6 +1100,11 @@ With the switch in the 12 (unlighted) position, transposition stays with the key
 
         //[/UserButtonCode_transposeHelp]
     }
+    else if (buttonThatWasClicked == glissendo.get())
+    {
+        //[UserButtonCode_glissendo] -- add your button handler code here..
+        //[/UserButtonCode_glissendo]
+    }
 
     //[UserbuttonClicked_Post]
     if( ! handled )
@@ -1206,13 +1261,13 @@ void ParamDialog::setIsStandardTuning( bool b )
         resetTuningButton->setEnabled( ! b );
 }
 
-// Force the internal component dialog to have keyboard focus. Ugly, but it is 
+// Force the internal component dialog to have keyboard focus. Ugly, but it is
 // the only way I have found (including on the JUCE forum).
 void ParamDialog::timerCallback() {
     stopTimer();
     grabKeyboardFocus();
 }
- 
+
 //[/MiscUserCode]
 
 
@@ -1228,7 +1283,7 @@ BEGIN_JUCER_METADATA
 <JUCER_COMPONENT documentType="Component" className="ParamDialog" componentName=""
                  parentClasses="public Component" constructorParams="" variableInitialisers=""
                  snapPixels="4" snapActive="1" snapShown="1" overlayOpacity="0.330"
-                 fixedSize="1" initialWidth="710" initialHeight="355">
+                 fixedSize="1" initialWidth="710" initialHeight="370">
   <BACKGROUND backgroundColour="ff3c322f">
     <TEXT pos="20 16 276 23" fill="solid: ffffffff" hasStroke="0" text="Pitch Bend Range"
           fontname="Default font" fontsize="15.0" kerning="0.0" bold="0"
@@ -1236,7 +1291,7 @@ BEGIN_JUCER_METADATA
     <TEXT pos="20 56 276 23" fill="solid: ffffffff" hasStroke="0" text="Pitch Bend Step"
           fontname="Default font" fontsize="15.0" kerning="0.0" bold="0"
           italic="0" justification="33"/>
-    <TEXT pos="20 318 245 23" fill="solid: ffffffff" hasStroke="0" text="DX7 Channel"
+    <TEXT pos="24 319 245 23" fill="solid: ffffffff" hasStroke="0" text="DX7 Channel"
           fontname="Default font" fontsize="15.0" kerning="0.0" bold="0"
           italic="0" justification="33"/>
     <TEXT pos="20 190 276 23" fill="solid: ffffffff" hasStroke="0" text="Engine Resolution"
@@ -1247,7 +1302,7 @@ BEGIN_JUCER_METADATA
     <TEXT pos="20 96 276 23" fill="solid: ffffffff" hasStroke="0" text="Show Keyboard"
           fontname="Default font" fontsize="15.0" kerning="0.0" bold="0"
           italic="0" justification="33"/>
-    <RECT pos="352 11 1 330" fill="solid: ff000000" hasStroke="0"/>
+    <RECT pos="352 12 1 349" fill="solid: ff000000" hasStroke="0"/>
     <TEXT pos="368 16 276 23" fill="solid: ffffffff" hasStroke="0" text="Wheel"
           fontname="Default font" fontsize="15.0" kerning="0.0" bold="0"
           italic="0" justification="33"/>
@@ -1269,24 +1324,24 @@ BEGIN_JUCER_METADATA
     <TEXT pos="640 163 48 23" fill="solid: ffffffff" hasStroke="0" text="EG BIAS"
           fontname="Default font" fontsize="15.0" kerning="0.0" bold="0"
           italic="0" justification="36"/>
-    <RECT pos="371 194 325 1" fill="solid: ff000000" hasStroke="0"/>
+    <RECT pos="376 194 325 1" fill="solid: ff000000" hasStroke="0"/>
     <TEXT pos="371 208 276 25" fill="solid: ffffffff" hasStroke="0" text="Tuning"
           fontname="Default font" fontsize="15.0" kerning="0.0" bold="0"
           italic="0" justification="33"/>
     <TEXT pos="371 242 157 25" fill="solid: ffffffff" hasStroke="0" text="Transposition 12 as:"
           fontname="Default font" fontsize="15.0" kerning="0.0" bold="0"
           italic="0" justification="33"/>
-    <RECT pos="368 280 328 1" fill="solid: ff000000" hasStroke="0"/>
-    <TEXT pos="371 290 276 27" fill="solid: ffffffff" hasStroke="0" text="MPE"
+    <RECT pos="368 310 328 1" fill="solid: ff000000" hasStroke="0"/>
+    <TEXT pos="368 322 276 27" fill="solid: ffffffff" hasStroke="0" text="MPE"
           fontname="Default font" fontsize="15.0" kerning="0.0" bold="0"
           italic="0" justification="33"/>
-    <TEXT pos="528 290 119 27" fill="solid: ffffffff" hasStroke="0" text="Bend Range"
+    <TEXT pos="528 322 119 27" fill="solid: ffffffff" hasStroke="0" text="Bend Range"
           fontname="Default font" fontsize="15.0" kerning="0.0" bold="0"
           italic="0" justification="33"/>
-    <TEXT pos="555 242 37 25" fill="solid: ffffffff" hasStroke="0" text="12"
+    <TEXT pos="548 242 37 25" fill="solid: ffffffff" hasStroke="0" text="12"
           fontname="Default font" fontsize="15.0" kerning="0.0" bold="0"
           italic="0" justification="33"/>
-    <TEXT pos="659 242 45 25" fill="solid: ffffffff" hasStroke="0" text="SCL"
+    <TEXT pos="628 242 45 25" fill="solid: ffffffff" hasStroke="0" text="SCL"
           fontname="Default font" fontsize="15.0" kerning="0.0" bold="0"
           italic="0" justification="33"/>
     <TEXT pos="147 16 20 23" fill="solid: ffffffff" hasStroke="0" text="up"
@@ -1298,6 +1353,12 @@ BEGIN_JUCER_METADATA
     <TEXT pos="20 136 276 23" fill="solid: ffffffff" hasStroke="0" text="UI Scaling"
           fontname="Default font" fontsize="15.0" kerning="0.0" bold="0"
           italic="0" justification="33"/>
+    <TEXT pos="371 277 184 23" fill="solid: ffffffff" hasStroke="0" text="Portamento Rate"
+          fontname="Default font" fontsize="15.0" kerning="0.0" bold="0"
+          italic="0" justification="33"/>
+    <TEXT pos="612 274 75 27" fill="solid: ffffffff" hasStroke="0" text="Glissendo"
+          fontname="Default font" fontsize="15.0" kerning="0.0" bold="0"
+          italic="0" justification="34"/>
   </BACKGROUND>
   <SLIDER name="pitchRangeDn" id="7409be5a8dfaa91" memberName="pitchRangeDn"
           virtualName="" explicitFocusOrder="2" pos="264 16 72 24" min="0.0"
@@ -1316,7 +1377,7 @@ BEGIN_JUCER_METADATA
             explicitFocusOrder="8" pos="104 280 224 24" editable="0" layout="33"
             items="" textWhenNonSelected="" textWhenNoItems="(no choices)"/>
   <SLIDER name="sysexChl" id="7fdc8830f90a7c86" memberName="sysexChl" virtualName=""
-          explicitFocusOrder="9" pos="264 316 72 24" min="1.0" max="16.0"
+          explicitFocusOrder="9" pos="252 320 72 24" min="1.0" max="16.0"
           int="1.0" style="RotaryVerticalDrag" textBoxPos="TextBoxLeft"
           textBoxEditable="1" textBoxWidth="80" textBoxHeight="20" skewFactor="1.0"
           needsCallback="1"/>
@@ -1397,16 +1458,16 @@ BEGIN_JUCER_METADATA
               virtualName="" explicitFocusOrder="29" pos="632 205 48 30" buttonText="Reset"
               connectedEdges="0" needsCallback="1" radioGroupId="0"/>
   <TOGGLEBUTTON name="transposeScale" id="9d4dd65775ed9e38" memberName="transposeScale"
-                virtualName="LightedToggleButton" explicitFocusOrder="30" pos="592 240 56 30"
+                virtualName="LightedToggleButton" explicitFocusOrder="30" pos="576 240 56 30"
                 buttonText="" connectedEdges="0" needsCallback="1" radioGroupId="0"
                 state="1"/>
   <SLIDER name="mpePBRange" id="a13948d1cc74a51a" memberName="mpePBRange"
-          virtualName="" explicitFocusOrder="32" pos="616 291 72 24" min="0.0"
+          virtualName="" explicitFocusOrder="32" pos="616 323 72 24" min="0.0"
           max="96.0" int="1.0" style="RotaryVerticalDrag" textBoxPos="TextBoxLeft"
           textBoxEditable="1" textBoxWidth="80" textBoxHeight="20" skewFactor="1.0"
           needsCallback="1"/>
   <TOGGLEBUTTON name="mpeEnabled" id="e1a11d0372879dd8" memberName="mpeEnabled"
-                virtualName="LightedToggleButton" explicitFocusOrder="31" pos="448 288 56 30"
+                virtualName="LightedToggleButton" explicitFocusOrder="31" pos="456 320 48 30"
                 buttonText="" connectedEdges="0" needsCallback="1" radioGroupId="0"
                 state="0"/>
   <IMAGEBUTTON name="new button" id="1c9edab9992cbeef" memberName="transposeHelp"
@@ -1424,6 +1485,15 @@ BEGIN_JUCER_METADATA
             virtualName="" explicitFocusOrder="5" pos="236 136 90 24" editable="0"
             layout="33" items="100 %&#10;125 %&#10;150 %&#10;200 %&#10;300 %&#10;400 %"
             textWhenNonSelected="" textWhenNoItems="(no choices)"/>
+  <TOGGLEBUTTON name="glissendo" id="f531397d4cf195a6" memberName="glissendo"
+                virtualName="LightedToggleButton" explicitFocusOrder="30" pos="576 272 56 30"
+                buttonText="" connectedEdges="0" needsCallback="1" radioGroupId="0"
+                state="1"/>
+  <SLIDER name="portamentoTm" id="12588a21a3ec6c02" memberName="portamentoTm"
+          virtualName="" explicitFocusOrder="22" pos="504 276 72 24" min="0.0"
+          max="99.0" int="1.0" style="RotaryVerticalDrag" textBoxPos="TextBoxLeft"
+          textBoxEditable="1" textBoxWidth="80" textBoxHeight="20" skewFactor="1.0"
+          needsCallback="1"/>
 </JUCER_COMPONENT>
 
 END_JUCER_METADATA

--- a/Source/ParamDialog.cpp
+++ b/Source/ParamDialog.cpp
@@ -1150,7 +1150,7 @@ void ParamDialog::setDialogValues(Controllers &c, SysexComm &mgr, int reso, bool
     mpeEnabled->setToggleState(c.mpeEnabled, dontSendNotification);
     mpePBRange->setValue(c.mpePitchBendRange, dontSendNotification);
 
-    portamentoTm->setValue(c.portamento_cc);
+    portamentoTm->setValue(c.portamento_cc * 100.0f / 127.0f); // Convert from 0-127 range to 0-100%
     glissendo->setToggleState(c.portamento_gliss_cc, dontSendNotification);
 
     StringArray inputs = MidiInput::getDevices();
@@ -1190,7 +1190,6 @@ bool ParamDialog::getDialogValues(Controllers &c, SysexComm &mgr, int *reso, boo
     c.values_[kControllerPitchRangeUp] = pitchRangeUp->getValue();
     c.values_[kControllerPitchRangeDn] = pitchRangeDn->getValue();
     c.values_[kControllerPitchStep] = pitchStep->getValue();
-    c.values_[kControllerPortamentoGlissando] = portamentoTm->getValue();
 
     c.wheel.range = whlRange->getValue();
     c.wheel.pitch = whlPitch->getToggleState();
@@ -1217,7 +1216,7 @@ bool ParamDialog::getDialogValues(Controllers &c, SysexComm &mgr, int *reso, boo
     c.mpeEnabled = mpeEnabled->getToggleState();
     c.mpePitchBendRange = mpePBRange->getValue();
 
-    c.portamento_cc = portamentoTm->getValue();
+    c.portamento_cc = portamentoTm->getValue() * 127.0f / 100.0f; // Convert to 0-127 range
     c.portamento_enable_cc = c.portamento_cc > 0;
     c.portamento_gliss_cc = glissendo->getToggleState();
 
@@ -1226,6 +1225,7 @@ bool ParamDialog::getDialogValues(Controllers &c, SysexComm &mgr, int *reso, boo
     if ( ! JUCEApplication::isStandaloneApp() ) {
         ret &= mgr.setInput(sysexIn->getItemText(sysexIn->getSelectedItemIndex()));
     }
+
     ret &= mgr.setOutput(sysexOut->getItemText(sysexOut->getSelectedItemIndex()));
     mgr.setChl(sysexChl->getValue() - 1);
 

--- a/Source/ParamDialog.h
+++ b/Source/ParamDialog.h
@@ -7,7 +7,7 @@
   the "//[xyz]" and "//[/xyz]" sections will be retained when the file is loaded
   and re-saved.
 
-  Created with Projucer version: 7.0.9
+  Created with Projucer version: 7.0.11
 
   ------------------------------------------------------------------------------
 
@@ -20,7 +20,6 @@
 #pragma once
 
 //[Headers]     -- You can add your own extra header files here --
-#include "JuceHeader.h"
 #include "msfa/controllers.h"
 #include "SysexComm.h"
 #include <functional>
@@ -41,7 +40,7 @@ class ParamDialog  : public Component,
                      public juce::Slider::Listener,
                      public juce::ComboBox::Listener,
                      public juce::Button::Listener,
-                     Timer
+                     public juce::Timer
 {
 public:
     //==============================================================================
@@ -116,6 +115,8 @@ private:
     std::unique_ptr<juce::ImageButton> transposeHelp;
     std::unique_ptr<juce::Slider> pitchRangeUp;
     std::unique_ptr<juce::ComboBox> scalingFactor;
+    std::unique_ptr<LightedToggleButton> glissendo;
+    std::unique_ptr<juce::Slider> portamentoTm;
 
 
     //==============================================================================

--- a/Source/ParamDialog.h
+++ b/Source/ParamDialog.h
@@ -115,7 +115,7 @@ private:
     std::unique_ptr<juce::ImageButton> transposeHelp;
     std::unique_ptr<juce::Slider> pitchRangeUp;
     std::unique_ptr<juce::ComboBox> scalingFactor;
-    std::unique_ptr<LightedToggleButton> glissendo;
+    std::unique_ptr<LightedToggleButton> glissando;
     std::unique_ptr<juce::Slider> portamentoTm;
 
 

--- a/Source/PluginData.cpp
+++ b/Source/PluginData.cpp
@@ -330,7 +330,8 @@ void DexedAudioProcessor::getStateInformation(MemoryBlock& destData) {
     dexedState.setAttribute("transpose12AsScale", controllers.transpose12AsScale ? 1 : 0 );
     dexedState.setAttribute("mpeEnabled", controllers.mpeEnabled ? 1 : 0 );
     dexedState.setAttribute("mpePitchBendRange", controllers.mpePitchBendRange );
-    
+    dexedState.setAttribute("monoMode", monoMode ? 1 : 0);
+
     char mod_cfg[15];
     controllers.wheel.setConfig(mod_cfg);
     dexedState.setAttribute("wheelMod", mod_cfg);

--- a/Source/PluginData.cpp
+++ b/Source/PluginData.cpp
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright (c) 2014-2017 Pascal Gauthier.
+ * Copyright (c) 2014-2025 Pascal Gauthier.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -331,6 +331,8 @@ void DexedAudioProcessor::getStateInformation(MemoryBlock& destData) {
     dexedState.setAttribute("mpeEnabled", controllers.mpeEnabled ? 1 : 0 );
     dexedState.setAttribute("mpePitchBendRange", controllers.mpePitchBendRange );
     dexedState.setAttribute("monoMode", monoMode ? 1 : 0);
+    dexedState.setAttribute("portamento", controllers.portamento_cc);
+    dexedState.setAttribute("glissando", controllers.portamento_gliss_cc ? 1 : 0);
 
     char mod_cfg[15];
     controllers.wheel.setConfig(mod_cfg);
@@ -401,9 +403,7 @@ void DexedAudioProcessor::setStateInformation(const void* source, int sizeInByte
     controllers.foot.parseConfig(root->getStringAttribute("footMod").toRawUTF8());
     controllers.breath.parseConfig(root->getStringAttribute("breathMod").toRawUTF8());
     controllers.at.parseConfig(root->getStringAttribute("aftertouchMod").toRawUTF8());
-    
-    controllers.refresh();
-    
+
     setEngineType(root->getIntAttribute("engineType", 1));
     monoMode = root->getIntAttribute("monoMode", 0);
     controllers.masterTune = root->getIntAttribute("masterTune", 0);
@@ -411,7 +411,15 @@ void DexedAudioProcessor::setStateInformation(const void* source, int sizeInByte
 
     controllers.mpePitchBendRange = ( root->getIntAttribute("mpePitchBendRange", 24) );
     controllers.mpeEnabled = ( root->getIntAttribute("mpeEnabled", 0) != 0 );
-    
+
+    controllers.portamento_cc = ( root->getIntAttribute("portamento", 0) );
+    controllers.portamento_enable_cc = controllers.portamento_cc > 1;
+    controllers.portamento_gliss_cc = ( root->getIntAttribute("glissando", 0) );
+
+    TRACE("READING :::::: controllers.portamento_cc=%d, glissando=%d", controllers.portamento_cc, controllers.portamento_gliss_cc);
+
+    controllers.refresh();
+
     File possibleCartridge = File(root->getStringAttribute("activeFileCartridge"));
     if ( possibleCartridge.exists() )
         activeFileCartridge = possibleCartridge;

--- a/Source/PluginData.cpp
+++ b/Source/PluginData.cpp
@@ -26,7 +26,6 @@
 #include "Dexed.h"
 
 #include <fstream>
-using namespace ::std;
 
 uint8_t sysexChecksum(const uint8_t *sysex, int size) {
     int sum = 0;

--- a/Source/PluginData.cpp
+++ b/Source/PluginData.cpp
@@ -275,7 +275,7 @@ void DexedAudioProcessor::sendCurrentSysexProgram() {
 
 void DexedAudioProcessor::sendCurrentSysexCartridge() {
     uint8_t raw[4104];
-    
+
     currentCart.saveVoice(raw);
     raw[2] = raw[2] | sysexComm.getChl();
     if ( sysexComm.isOutputActive() ) {

--- a/Source/PluginData.cpp
+++ b/Source/PluginData.cpp
@@ -415,9 +415,6 @@ void DexedAudioProcessor::setStateInformation(const void* source, int sizeInByte
     controllers.portamento_cc = ( root->getIntAttribute("portamento", 0) );
     controllers.portamento_enable_cc = controllers.portamento_cc > 1;
     controllers.portamento_gliss_cc = ( root->getIntAttribute("glissando", 0) );
-
-    TRACE("READING :::::: controllers.portamento_cc=%d, glissando=%d", controllers.portamento_cc, controllers.portamento_gliss_cc);
-
     controllers.refresh();
 
     File possibleCartridge = File(root->getStringAttribute("activeFileCartridge"));

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -155,9 +155,7 @@ void DexedAudioProcessor::prepareToPlay(double sampleRate, int samplesPerBlock) 
     controllers.foot_cc = 0;
     controllers.breath_cc = 0;
     controllers.aftertouch_cc = 0;
-    controllers.portamento_enable_cc = false;
-    controllers.portamento_cc = 0;
-	controllers.refresh(); 
+	controllers.refresh();
 
     sustain = false;
     extra_buf_size = 0;
@@ -357,14 +355,15 @@ void DexedAudioProcessor::processMidiMessage(const MidiMessage *msg) {
         {
             int i = voiceIndex;
             switch(cf0) {
-            case 0xb0:
-                voices[i].mpeTimbre = (int)buf[2];
-                voices[i].dx7_note->mpeTimbre = (int)buf[2];
-                break;
-            case 0xd0:
-                voices[i].mpePressure = (int)buf[1];
-                voices[i].dx7_note->mpePressure = (int)buf[1];
-                break;
+            // THIS IS COMMENTED SINCE mepTimbre and mpePressure is not used
+            // case 0xb0:
+            //     voices[i].mpeTimbre = (int)buf[2];
+            //     voices[i].dx7_note->mpeTimbre = (int)buf[2];
+            //     break;
+            // case 0xd0:
+            //     voices[i].mpePressure = (int)buf[1];
+            //     voices[i].dx7_note->mpePressure = (int)buf[1];
+            //     break;
             case 0xe0:
                 voices[i].mpePitchBend = (int)( buf[1] | (buf[2] << 7) );
                 voices[i].dx7_note->mpePitchBend = (int)( buf[1] | ( buf[2] << 7 ) );

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -625,65 +625,84 @@ void DexedAudioProcessor::handleIncomingMidiMessage(MidiInput* source, const Mid
 
     if ( ! message.isSysEx() )
         return;
-    
+
     // test if it is a Yamaha Sysex
     if ( buf[1] != 0x43 ) {
         TRACE("not a yamaha sysex %d", buf[1]);
         return;
     }
-    
+
     int substatus = buf[2] >> 4;
-    
-    if ( substatus == 0 ) {
-        // single voice dump
-        if ( buf[3] == 0 ) {
-            if ( sz < 156 ) {
-                TRACE("wrong single voice datasize %d", sz);
-                return;
+    switch(substatus) {
+        case 0 : {
+            // single voice dump
+            if ( buf[3] == 0 ) {
+                if ( sz < 156 ) {
+                    TRACE("wrong single voice datasize %d", sz);
+                    return;
+                }
+                if ( updateProgramFromSysex(buf+6) )
+                    TRACE("bad checksum when updating program from sysex message");
             }
-            if ( updateProgramFromSysex(buf+6) )
-                TRACE("bad checksum when updating program from sysex message");
-        }
-        
-        // 32 voice dump
-        if ( buf[3] == 9 ) {
-            if ( sz < 4104 ) {
-                TRACE("wrong 32 voice dump data size %d", sz);
-                return;
-            }
-            
-            Cartridge received;
-            if ( received.load(buf, sz) == 0 ) {
-                loadCartridge(received);
-                setCurrentProgram(0);
+
+            // 32 voice dump
+            if ( buf[3] == 9 ) {
+                if ( sz < 4104 ) {
+                    TRACE("wrong 32 voice dump data size %d", sz);
+                    return;
+                }
+
+                Cartridge received;
+                if ( received.load(buf, sz) == 0 ) {
+                    loadCartridge(received);
+                    setCurrentProgram(0);
+                }
             }
         }
-    } else if ( substatus == 1 ) {
-        // parameter change
-        if ( sz < 7 ) {
-           TRACE("wrong single voice datasize %d", sz);
-           return;
-        }
-        
-        uint8 offset = (buf[3] << 7) + buf[4];
-        uint8 value = buf[5];
-        
-        TRACE("parameter change message offset:%d value:%d", offset, value);
-        
-        if ( offset > 155 ) {
-            TRACE("wrong offset size");
+        break;
+        case 1 : {
+            // parameter change
+            if ( sz < 7 ) {
+            TRACE("wrong single voice datasize %d", sz);
             return;
+            }
+
+            uint8 offset = (buf[3] << 7) + buf[4];
+            uint8 value = buf[5];
+
+            TRACE("parameter change message offset:%d value:%d", offset, value);
+
+            if ( offset > 155 ) {
+                TRACE("wrong offset size");
+                return;
+            }
+
+            if ( offset == 155 ) {
+                unpackOpSwitch(value);
+            } else {
+                data[offset] = value;
+            }
         }
-        
-        if ( offset == 155 ) {
-            unpackOpSwitch(value);
-        } else {
-            data[offset] = value;
+        break;
+        case 2: {
+            if ( buf[3] == 0 ) {
+                // single voice request
+                sendCurrentSysexProgram();
+            } else if ( buf[3] == 9 ) {
+                // cart request
+                sendCurrentSysexCartridge();
+            } else {
+                TRACE("Unknown voice request: %d", buf[3]);
+            }
         }
-    } else {
-        TRACE("unknown sysex substatus: %d", substatus);
+        return;
+
+        default: {
+            TRACE("unknown sysex substatus: %d", substatus);
+        }
+        return;
     }
-    
+
     forceRefreshUI = true;
     triggerAsyncUpdate();
 }
@@ -694,7 +713,7 @@ int DexedAudioProcessor::getEngineType() {
 
 void DexedAudioProcessor::setEngineType(int tp) {
     TRACE("settings engine %d", tp);
-    
+
     switch (tp)  {
         case DEXED_ENGINE_MARKI:
             controllers.core = &engineMkI;

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -387,8 +387,6 @@ void DexedAudioProcessor::processMidiMessage(const MidiMessage *msg) {
         case 0xb0 : {
             int ctrl = buf[1];
             int value = buf[2];
-
-
                 switch(ctrl) {
                 case 1:
                     controllers.modwheel_cc = value;
@@ -499,8 +497,9 @@ void DexedAudioProcessor::keydown(uint8_t channel, uint8_t pitch, uint8_t velo) 
             voices[note].dx7_note->init(data, pitch, velo, channel, &controllers);
             if ( data[136] )
                 voices[note].dx7_note->oscSync();
-            if ( controllers.portamento_enable_cc && voices[lastActiveVoice].midi_note != -1 ) {
-                voices[note].dx7_note->initPortamento(controllers.portamento_cc, *voices[lastActiveVoice].dx7_note);
+            if ( (voices[lastActiveVoice].midi_note != -1 && controllers.portamento_enable_cc)
+               && controllers.portamento_cc > 0 ) {
+                voices[note].dx7_note->initPortamento(*voices[lastActiveVoice].dx7_note);
             }
             break;
         }

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -47,9 +47,6 @@ struct ProcessorVoice {
     bool live;
 
     int mpePitchBend;
-    int mpePressure;
-    int mpeTimbre;
-    
     Dx7Note *dx7_note;
 };
 

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -254,6 +254,7 @@ public :
     static File dexedCartDir;
 
     Value lastCCUsed;
+    int lastKeyDown;
 
     MTSClient *mtsClient;
     std::shared_ptr<TuningState> synthTuningState;

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright (c) 2013-2017 Pascal Gauthier.
+ * Copyright (c) 2013-2025 Pascal Gauthier.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -254,7 +254,7 @@ public :
     static File dexedCartDir;
 
     Value lastCCUsed;
-    int lastKeyDown;
+    int lastActiveVoice = 0;
 
     MTSClient *mtsClient;
     std::shared_ptr<TuningState> synthTuningState;

--- a/Source/SysexComm.cpp
+++ b/Source/SysexComm.cpp
@@ -48,6 +48,9 @@ bool SysexComm::setInput(String target) {
         return true;
 #endif
 
+    if ( target == inputName )
+        return true;
+
     if ( input != NULL ) {
         input->stop();
         input = NULL;
@@ -56,7 +59,11 @@ bool SysexComm::setInput(String target) {
     
     if ( listener == NULL )
         return true;
-    
+
+    if ( target == "None" || target == "" ) {
+        return true;
+    }
+
     StringArray devices = MidiInput::getDevices();
     int idx = devices.indexOf(target);
 
@@ -93,7 +100,14 @@ bool SysexComm::setOutput(String target) {
         output = NULL;
     }
     inputOutput = false;
-    
+
+    if ( target == "None" || target == "" ) {
+        return true;
+    }
+
+    if ( target == outputName )
+        return true;
+
     StringArray devices = MidiOutput::getDevices();
     int idx = devices.indexOf(target);
     

--- a/Source/msfa/controllers.h
+++ b/Source/msfa/controllers.h
@@ -31,7 +31,6 @@ const uint8_t kControllerPitch = 128;
 const uint8_t kControllerPitchRangeUp = 129;
 const uint8_t kControllerPitchStep = 130;
 const uint8_t kControllerPitchRangeDn = 131;
-const uint8_t kControllerPortamentoGlissando = 3;
 
 class FmCore;
 

--- a/Source/msfa/controllers.h
+++ b/Source/msfa/controllers.h
@@ -27,10 +27,11 @@
 #endif
 
 // State of MIDI controllers
-const int kControllerPitch = 128;
-const int kControllerPitchRangeUp = 129;
-const int kControllerPitchStep = 130;
-const int kControllerPitchRangeDn = 131;
+const uint8_t kControllerPitch = 128;
+const uint8_t kControllerPitchRangeUp = 129;
+const uint8_t kControllerPitchStep = 130;
+const uint8_t kControllerPitchRangeDn = 131;
+const uint8_t kControllerPortamentoGlissando = 3;
 
 class FmCore;
 
@@ -89,7 +90,10 @@ public:
     int breath_cc;
     int foot_cc;
     int modwheel_cc;
-    
+    bool portamento_enable_cc;
+    int32_t portamento_cc;
+    bool portamento_gliss_cc;
+
     int masterTune;
 
     bool transpose12AsScale = true;

--- a/Source/msfa/dx7note.cc
+++ b/Source/msfa/dx7note.cc
@@ -49,12 +49,15 @@ int32_t logfreq_round2semi(int freq) {
   return freq - rem;
 }
 
-int32_t Dx7Note::osc_freq(int midinote, int mode, int coarse, int fine, int detune) {
+int32_t osc_freq(int midinote, int mode, int coarse, int fine, int detune) {
 
     // TODO: pitch randomization
     int32_t logfreq;
     if (mode == 0) {
-        logfreq = noteLogFreq;
+        // TODO: OH LA LA, midinote is not used since mts. This should be merged
+        // with the original portamento code.  
+        // logfreq = noteLogFreq;
+        logfreq = midinote_to_logfreq(midinote);
 
         // could use more precision, closer enough for now. those numbers comes from my DX7
         double detuneRatio = 0.0209 * exp(-0.396 * (((float)logfreq)/(1<<24))) / 7;
@@ -202,8 +205,9 @@ void Dx7Note::init(const uint8_t patch[156], int midinote, int velocity, int cha
         porta_curpitch_[op] = freq;
         ampmodsens_[op] = ampmodsenstab[patch[off + 14] & 3];
 
-        if (porta >= 0)
+        if (porta >= 0) {
             porta_curpitch_[op] = osc_freq(srcnote, mode, coarse, fine, detune);
+        }
     }
     for (int i = 0; i < 4; i++) {
         rates[i] = patch[126 + i];
@@ -300,8 +304,8 @@ void Dx7Note::compute(int32_t *buf, int32_t lfo_val, int32_t lfo_delay, const Co
             } else {
                 if ( porta_rateindex_ >= 0 ) {
                     basepitch = porta_curpitch_[op];
-                if ( porta_gliss_ )
-                    basepitch = logfreq_round2semi(basepitch);
+                    if ( porta_gliss_ )
+                        basepitch = logfreq_round2semi(basepitch);
                 }
                 params_[op].freq = Freqlut::lookup(basepitch + pitch_mod);
             }

--- a/Source/msfa/dx7note.cc
+++ b/Source/msfa/dx7note.cc
@@ -280,7 +280,7 @@ void Dx7Note::compute(int32_t *buf, int32_t lfo_val, int32_t lfo_delay, const Co
     int porta_rate;
     if ( ctrls->portamento_enable_cc ) {
         if ( ctrls->portamento_gliss_cc )
-            porta_rate = Porta::rates_glissendo[ctrls->portamento_cc];
+            porta_rate = Porta::rates_glissando[ctrls->portamento_cc];
         else
             porta_rate = Porta::rates[ctrls->portamento_cc];
     } else {

--- a/Source/msfa/dx7note.h
+++ b/Source/msfa/dx7note.h
@@ -63,7 +63,8 @@ public:
     void transferPortamento(Dx7Note &src);
     void oscSync();
 
-    int32_t osc_freq(int midinote, int mode, int coarse, int fine, int detune);
+    // We should put this as a function and not a DX7Note method
+    //int32_t osc_freq(int midinote, int mode, int coarse, int fine, int detune);
 
     std::shared_ptr<TuningState> tuning_state_;
 

--- a/Source/msfa/dx7note.h
+++ b/Source/msfa/dx7note.h
@@ -41,7 +41,9 @@ struct VoiceStatus {
 class Dx7Note {
 public:
     Dx7Note(std::shared_ptr<TuningState> ts, MTSClient *mtsc);
-    void init(const uint8_t patch[156], int midinote, int velocity, int channel, int srcnote, int porta, const Controllers *ctrls);
+    void init(const uint8_t patch[156], int midinote, int velocity, int channel, const Controllers *ctrls);
+    void initPortamento(int level, const Dx7Note &srcNote);
+
     // Note: this _adds_ to the buffer. Interesting question whether it's
     // worth it...
     void compute(int32_t *buf, int32_t lfo_val, int32_t lfo_delay,
@@ -60,7 +62,6 @@ public:
     void peekVoiceStatus(VoiceStatus &status);
     void transferState(Dx7Note& src);
     void transferSignal(Dx7Note &src);
-    void transferPortamento(Dx7Note &src);
     void oscSync();
 
     // We should put this as a function and not a DX7Note method
@@ -96,11 +97,11 @@ private:
     int porta_gliss_;
     int32_t porta_curpitch_[6];
 
-    int32_t noteLogFreq;
+    //int32_t noteLogFreq;
     double mtsFreq;
     static const int32_t mtsLogFreqToNoteLogFreq;
     MTSClient *mtsClient;
-    
+    int32_t osc_freq(int midinote, int mode, int coarse, int fine, int detune, int channel);
 };
 
 #endif  // SYNTH_DX7NOTE_H_

--- a/Source/msfa/dx7note.h
+++ b/Source/msfa/dx7note.h
@@ -42,7 +42,7 @@ class Dx7Note {
 public:
     Dx7Note(std::shared_ptr<TuningState> ts, MTSClient *mtsc);
     void init(const uint8_t patch[156], int midinote, int velocity, int channel, const Controllers *ctrls);
-    void initPortamento(int level, const Dx7Note &srcNote);
+    void initPortamento(const Dx7Note &srcNote);
 
     // Note: this _adds_ to the buffer. Interesting question whether it's
     // worth it...
@@ -93,8 +93,6 @@ private:
     
     const uint8_t *currentPatch;
     
-    int porta_rateindex_;
-    int porta_gliss_;
     int32_t porta_curpitch_[6];
 
     //int32_t noteLogFreq;

--- a/Source/msfa/dx7note.h
+++ b/Source/msfa/dx7note.h
@@ -28,6 +28,7 @@
 #include "pitchenv.h"
 #include "fm_core.h"
 #include "tuning.h"
+#include "porta.h"
 #include "libMTSClient.h"
 #include <memory>
 
@@ -40,7 +41,7 @@ struct VoiceStatus {
 class Dx7Note {
 public:
     Dx7Note(std::shared_ptr<TuningState> ts, MTSClient *mtsc);
-    void init(const uint8_t patch[156], int midinote, int velocity, int channel);
+    void init(const uint8_t patch[156], int midinote, int velocity, int channel, int srcnote, int porta, const Controllers *ctrls);
     // Note: this _adds_ to the buffer. Interesting question whether it's
     // worth it...
     void compute(int32_t *buf, int32_t lfo_val, int32_t lfo_delay,
@@ -59,6 +60,7 @@ public:
     void peekVoiceStatus(VoiceStatus &status);
     void transferState(Dx7Note& src);
     void transferSignal(Dx7Note &src);
+    void transferPortamento(Dx7Note &src);
     void oscSync();
 
     int32_t osc_freq(int midinote, int mode, int coarse, int fine, int detune);
@@ -89,6 +91,10 @@ private:
     
     const uint8_t *currentPatch;
     
+    int porta_rateindex_;
+    int porta_gliss_;
+    int32_t porta_curpitch_[6];
+
     int32_t noteLogFreq;
     double mtsFreq;
     static const int32_t mtsLogFreqToNoteLogFreq;

--- a/Source/msfa/porta.cpp
+++ b/Source/msfa/porta.cpp
@@ -30,13 +30,13 @@ void Porta::init_sr(double sampleRate) {
         double spp = spf * N; // per period
         rates[i] = (int32_t) (0.5f + step * spp); // to pitch units
 
-        // glissendo seems to be slower if enabled
+        // glissando seems to be slower if enabled
         sps = 1300.0 * pow(2.0, -0.062 * i); // per second
         spf = sps / sampleRate; // per frame
         spp = spf * N; // per period
-        rates_glissendo[i] = (int32_t) (0.5f + step * spp); // to pitch units
+        rates_glissando[i] = (int32_t) (0.5f + step * spp); // to pitch units
     }
 }
 
 int32_t Porta::rates[128];
-int32_t Porta::rates_glissendo[128];
+int32_t Porta::rates_glissando[128];

--- a/Source/msfa/porta.cpp
+++ b/Source/msfa/porta.cpp
@@ -1,0 +1,35 @@
+/*
+   Copyright 2019 Jean Pierre Cimalando.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include <math.h>
+#include "porta.h"
+#include "synth.h"
+
+void Porta::init_sr(double sampleRate)
+{
+  // compute portamento for CC 7-bit range
+
+  for (uint8_t i = 0; i < 128; ++i) {
+    // number of semitones travelled
+    double sps = 350.0 * pow(2.0, -0.062 * i);  // per second
+    double spf = sps / sampleRate;              // per frame
+    double spp = spf * N;                       // per period
+    const int32_t step = (1 << 24) / 12;
+    rates[i] = (int32_t)(0.5f + step * spp);    // to pitch units
+  }
+}
+
+int32_t Porta::rates[128];

--- a/Source/msfa/porta.cpp
+++ b/Source/msfa/porta.cpp
@@ -18,18 +18,23 @@
 #include "porta.h"
 #include "synth.h"
 
-void Porta::init_sr(double sampleRate)
-{
-  // compute portamento for CC 7-bit range
+void Porta::init_sr(double sampleRate) {
+    // compute portamento for CC 7-bit range
 
-  for (uint8_t i = 0; i < 128; ++i) {
-    // number of semitones travelled
-    double sps = 350.0 * pow(2.0, -0.062 * i);  // per second
-    double spf = sps / sampleRate;              // per frame
-    double spp = spf * N;                       // per period
-    const int32_t step = (1 << 24) / 12;
-    rates[i] = (int32_t)(0.5f + step * spp);    // to pitch units
-  }
+    for (uint8_t i = 0; i < 128; ++i) {
+        // number of semitones travelled
+        double sps = 350 * pow(2.0, -0.062 * i); // per second
+        double spf = sps / sampleRate; // per frame
+        double spp = spf * N; // per period
+        const int32_t step = (1 << 24) / 12;
+        rates[i] = (int32_t) (0.5f + step * spp); // to pitch units
+
+        sps = 184.0 * pow(2.0, -0.062 * i); // per second
+        spf = sps / sampleRate; // per frame
+        spp = spf * N; // per period
+        rates_glissendo[i] = (int32_t) (0.5f + step * spp); // to pitch units
+    }
 }
 
 int32_t Porta::rates[128];
+int32_t Porta::rates_glissendo[128];

--- a/Source/msfa/porta.cpp
+++ b/Source/msfa/porta.cpp
@@ -22,14 +22,16 @@ void Porta::init_sr(double sampleRate) {
     // compute portamento for CC 7-bit range
 
     for (uint8_t i = 0; i < 128; ++i) {
+        const int32_t step = (1 << 24) / 12;
+
         // number of semitones travelled
-        double sps = 350 * pow(2.0, -0.062 * i); // per second
+        double sps = 2100.0 * pow(2.0, -0.062 * i); // per second
         double spf = sps / sampleRate; // per frame
         double spp = spf * N; // per period
-        const int32_t step = (1 << 24) / 12;
         rates[i] = (int32_t) (0.5f + step * spp); // to pitch units
 
-        sps = 184.0 * pow(2.0, -0.062 * i); // per second
+        // glissendo seems to be slower if enabled
+        sps = 1300.0 * pow(2.0, -0.062 * i); // per second
         spf = sps / sampleRate; // per frame
         spp = spf * N; // per period
         rates_glissendo[i] = (int32_t) (0.5f + step * spp); // to pitch units

--- a/Source/msfa/porta.h
+++ b/Source/msfa/porta.h
@@ -1,0 +1,28 @@
+/*
+   Copyright 2019 Jean Pierre Cimalando.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#ifndef SYNTH_PORTA_H_
+#define SYNTH_PORTA_H_
+
+#include <stdint.h>
+
+struct Porta {
+  public:
+    static void init_sr(double sampleRate);
+    static int32_t rates[128];
+};
+
+#endif

--- a/Source/msfa/porta.h
+++ b/Source/msfa/porta.h
@@ -23,7 +23,7 @@ struct Porta {
   public:
     static void init_sr(double sampleRate);
     static int32_t rates[128];
-    static int32_t rates_glissendo[128];
+    static int32_t rates_glissando[128];
 };
 
 #endif

--- a/Source/msfa/porta.h
+++ b/Source/msfa/porta.h
@@ -23,6 +23,7 @@ struct Porta {
   public:
     static void init_sr(double sampleRate);
     static int32_t rates[128];
+    static int32_t rates_glissendo[128];
 };
 
 #endif


### PR DESCRIPTION
Implementation of PR #183 (thanks @jpcima for the original PR, but the code base was to far-away from the recent Dexed one) . 

Portamento is applied with current portamento value, not the last midi note. This way, the portamento is always calculated even if the voice is not playing. This way, when a new note plays, it starts at the current portamento value, not the last midi note.

* Glissando only works in standard tuning
* Mono mode portamento doesn't react like the DX7. I want to refactor the voice allocation in 1.x ; this will be the right time to implement this