### PR TITLE
Improve voice stealing logic to reduce clicking and interference

### DIFF
--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -45,6 +45,7 @@ struct ProcessorVoice {
     bool keydown;
     bool sustained;
     bool live;
+    int32_t keydown_seq;
 
     int mpePitchBend;
     Dx7Note *dx7_note;
@@ -284,6 +285,8 @@ public :
         return dpiScaleFactor;
     }    
 private:
+    int chooseNote(uint8_t pitch);
+    int32_t nextKeydownSeq;;
     //==============================================================================
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (DexedAudioProcessor)
 

--- a/Source/msfa/dx7note.h
+++ b/Source/msfa/dx7note.h
@@ -51,10 +51,7 @@ public:
     
     void keyup();
     
-    // TODO: some way of indicating end-of-note. Maybe should be a return
-    // value from the compute method? (Having a count return from keyup
-    // is also tempting, but if there's a dynamic parameter change after
-    // keyup, that won't work.
+    bool isPlaying();
     
     // PG:add the update
     void update(const uint8_t patch[156], int midinote, int velocity, int channel);
@@ -62,6 +59,7 @@ public:
     void peekVoiceStatus(VoiceStatus &status);
     void transferState(Dx7Note& src);
     void transferSignal(Dx7Note &src);
+    void transferPhase(Dx7Note &src);
     void oscSync();
 
     // We should put this as a function and not a DX7Note method
@@ -74,6 +72,7 @@ public:
     int mpeTimbre = 0;
     
 private:
+    bool initialised_;
     Env env_[6];
     FmOpParams params_[6];
     PitchEnv pitchenv_;

--- a/Source/msfa/env.cc
+++ b/Source/msfa/env.cc
@@ -44,11 +44,16 @@ const int statics[] = {
 };
 #endif
 
+Env::Env() {
+    initialised_ = false;
+}
+
 void Env::init_sr(double sampleRate) {
     sr_multiplier = (44100.0 / sampleRate) * (1<<24);
 }
 
 void Env::init(const int r[4], const int l[4], int ol, int rate_scaling) {
+    initialised_ = true;
     for (int i = 0; i < 4; i++) {
         rates_[i] = r[i];
         levels_[i] = l[i];
@@ -190,3 +195,7 @@ void Env::transfer(Env &src) {
     inc_ = src.inc_;
 }
 
+// an envelope is active if it's been initialised and either it hasn't reached L4 yet or L4 > 0
+bool Env::isActive() {
+    return initialised_ && (ix_ < 4 || levels_[3] > 0);
+}

--- a/Source/msfa/env.h
+++ b/Source/msfa/env.h
@@ -26,6 +26,7 @@
 
 class Env {
  public:
+  Env();
 
   // The rates and levels arrays are calibrated to match the Dx7 parameters
   // (ie, value 0..99). The outlevel parameter is calibrated in microsteps
@@ -50,8 +51,10 @@ class Env {
     
   static void init_sr(double sample_rate);
   void transfer(Env &src);
-    
+  bool isActive();
+
  private:
+  bool initialised_;
 
   // PG: This code is normalized to 44100, need to put a multiplier
   // if we are not using 44100.

--- a/Source/msfa/fm_core.cc
+++ b/Source/msfa/fm_core.cc
@@ -133,3 +133,7 @@ void FmCore::render(int32_t *output, FmOpParams *params, int algorithm, int32_t 
         param.phase += param.freq << LG_N;
     }
 }
+
+bool FmCore::isCarrier(int algorithm, int op) {
+  return (algorithms[algorithm].ops[op] & FmOperatorFlags::OUT_BUS_ADD) != 0;
+}

--- a/Source/msfa/fm_core.h
+++ b/Source/msfa/fm_core.h
@@ -48,6 +48,7 @@ class FmCore {
 public:
     virtual ~FmCore() {};
     static void dump();
+    static bool isCarrier(int algorithm, int op);
     virtual void render(int32_t *output, FmOpParams *params, int algorithm, int32_t *fb_buf, int32_t feedback_gain);
 protected:
     AlignedBuf<int32_t, N>buf_[2];


### PR DESCRIPTION
This PR changes the voice stealing logic to reduce clicking, including the clicking that was introduced by #488 when trying to avoid destructive interference between notes with the same pitch.

Previously, when choosing a voice for a new note, any voice with its key up could be chosen, regardless of whether it was still releasing. This could cause clicking for patches with long release times. A round-robin based on `currentNote` made older notes more likely to be chosen in the common case where keys were released in the same order as they were pressed.

With this PR, we first try to find a voice that's not playing. This is determined by examining the amp envelopes of the carrier operators. (If there are no active carriers then we don't mind whether modulators are still active, as they won't be heard.)

If all voices are playing then we have to steal a voice. As before, we prefer a voice with its key up to one with its key down. If all voices have the same key state then we prefer a voice with the same pitch as the new note, as a change in pitch makes the stealing more noticeable.

These preferences make us less likely to choose voices in a round-robin order, so the round-robin based on `currentNote` is no longer effective for replacing the oldest note. Instead, we keep track of the order in which keys are pressed and prefer to steal a voice whose key was pressed earlier, all else being equal.

To remove another source of clicking, oscillator sync is not applied when stealing a voice.

The logic added in #488 for transferring state from another note with the same pitch is updated to transfer only the phase, to avoid clicks due to transferring the operator gain. A bug that could have cause the new note to transfer phase from itself (a no-op) is fixed.

This PR also fixes a TODO regarding LFO triggering. The method for determining whether a note is active appears to fix another TODO.