### PR TITLE
Auto Copy Feature

### DIFF
--- a/Source/CartManager.cpp
+++ b/Source/CartManager.cpp
@@ -256,6 +256,36 @@ void CartManager::programSelected(ProgramListBox *source, int pos) {
     }
 }
 
+void CartManager::programAutoCopied(ProgramListBox *source, int pos) {
+
+    ProgramListBox *otherListBox;
+
+    if ( source == activeCart.get() ) {
+        otherListBox = browserCart.get();
+    } else {
+        otherListBox = activeCart.get();
+    }
+
+    int i;
+    int foundIndex = -1;
+
+    for ( i = 0; i < otherListBox->programNames.size(); i++ ) {
+        if ( otherListBox->programNames[i] == "-         " || otherListBox->programNames[i] == "          " ) {
+            foundIndex = i;
+            break;
+        }
+    }
+
+    if ( foundIndex < 0 ){
+        AlertWindow::showMessageBoxAsync (AlertWindow::WarningIcon, "Auto Copy", "No free program slot found!");
+        return;
+    }
+
+   char *sourceSysExPointer = source->getCurrentCart().getRawVoice() + (pos*128);
+
+   programDragged(otherListBox,  foundIndex, sourceSysExPointer);   
+}
+
 void CartManager::buttonClicked(juce::Button *buttonThatWasClicked) {
     if ( buttonThatWasClicked == closeButton.get() ) {
         hideCartridgeManager();

--- a/Source/CartManager.h
+++ b/Source/CartManager.h
@@ -106,6 +106,7 @@ public:
     virtual void programSelected(ProgramListBox *source, int pos) override;
     virtual void programRightClicked(ProgramListBox *source, int pos) override;
     virtual void programDragged(ProgramListBox *destListBox, int dest, char *packedPgm) override;
+    virtual void programAutoCopied(ProgramListBox *source, int pos) override;
     virtual bool keyPressed(const KeyPress& key, Component* originatingComponent) override;
 
     void initialFocus();

--- a/Source/ProgramListBox.cpp
+++ b/Source/ProgramListBox.cpp
@@ -81,7 +81,7 @@ bool ProgramListBox::keyPressed(const KeyPress &key, Component *originatingCompo
     if ( key.isKeyCode(KeyPress::returnKey) ) {
         activePgm = programLabel->idx;
         if ( activePgm != -1 ) {
-            listener->programSelected(this, activePgm);
+            listener->programAutoCopied(this, activePgm);
         }
         return true;
     }

--- a/Source/ProgramListBox.h
+++ b/Source/ProgramListBox.h
@@ -32,6 +32,7 @@ public:
     virtual void programSelected(ProgramListBox *source, int pos) = 0;
     virtual void programRightClicked(ProgramListBox *source, int pos) = 0;
     virtual void programDragged(ProgramListBox *destListBox, int dest, char *packedPgm) = 0;
+    virtual void programAutoCopied(ProgramListBox *source, int pos) = 0;
 };
 
 class ProgramLabel;


### PR DESCRIPTION
Use Enter key to quickly copy a sound (instead of selecting).
The destination will be found automatically: It will be the first "empty" program slot in the opposite ProgramListBox.
"Empty" is a sound the name of which is either "-" or empty. 