### PR TITLE
Fix scale factor bug on Linux

### DIFF
--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -445,9 +445,8 @@ float DexedAudioProcessorEditor::getLargestScaleFactor() {
 
         // validate if there is really a display that can show the complete plugin size
         for (auto& display : Desktop::getInstance().getDisplays().displays) {
-            float ratio = display.scale;
-            int height = ratio * display.userArea.getHeight();
-            int width = ratio * display.userArea.getWidth();
+            const int height = display.userArea.getHeight();
+            const int width = display.userArea.getWidth();
 
             TRACE("Testing size %d x %d < Dexed Window %d x %d", height, width, rect.getWidth(), rect.getHeight() );
             if ( height > rect.getHeight() && width > rect.getWidth() ) {


### PR DESCRIPTION
I ran into this issue on Linux (Fedora 43, using Gnome on Wayland) using the Standalone Dexed version: https://github.com/asb2m10/dexed/issues/239

Issue was closed, but it seems to still be an existent bug on Linux. And, I think it also effects MacOS, based on the report and my understanding of the code.

As far as I can tell, this multiplication by `display.scale` is multiplying an already HiDPI scaled value, causing it to end up possibly several times the actual screen size. Making this change corrects it for me on Linux. I can't find anywhere this would cause problems, but I don't understand how plugins get sized and if this might somehow be breaking for that...I can load the VST into Carla and it looks fine (though it gets scale 1, while standalone version is scaled up to a more reasonable size).

I'll try to get access to a Windows machine to test on, if you want to ignore this PR for a while, but I figured I'd get it in front of you, as you may be able to spot why this has side effects I can't spot. This calculation must be there for some reason, but it definitely behaves badly on Linux with a HiDPI display.

I see you're also in the middle of some scaling work on this [PR](https://github.com/asb2m10/dexed/pull/502), so maybe that also corrects this problem in a different way, I dunno.