### PR TITLE
Safety fixes, random voice generator, resizable UI, 4-op sysex import

### DIFF
--- a/.github/workflows/project-pipeline.yml
+++ b/.github/workflows/project-pipeline.yml
@@ -27,7 +27,7 @@ jobs:
       - name: "Calculate version"
         id: vers
         run: |
-          ref=${{ github.ref }}
+          ref="${GITHUB_REF}"
 
           echo "## Creating version from '${ref}'" >> $GITHUB_STEP_SUMMARY
 
@@ -87,7 +87,7 @@ jobs:
 
     - name: Build
       run: |
-        cmake -S . -B ./build -DCMAKE_BUILD_TYPE=${{ needs.component_version.outputs.build_type }} -DBUILD_ID=${{ needs.component_version.outputs.build_version }} -DCOPY_PLUGIN_AFTER_BUILD=FALSE
+        cmake -S . -B ./build -DCMAKE_BUILD_TYPE=${{ needs.component_version.outputs.build_type }} -DBUILD_ID=${{ needs.component_version.outputs.build_version }} -DJUCE_COPY_PLUGIN_AFTER_BUILD=FALSE
         cmake --build ./build --config ${{ needs.component_version.outputs.build_type }} --target installer --parallel 3
 
     - name: Upload

--- a/Source/AlgoDisplay.cpp
+++ b/Source/AlgoDisplay.cpp
@@ -30,7 +30,7 @@ AlgoDisplay::AlgoDisplay() {
 void AlgoDisplay::displayOp(Graphics &g, char id, int x, int y, char link, char fb) {
     const int LINE_SZ = 3;
     String t(id);
-    bool opOn = opStatus[6-id] == '1';
+    bool opOn = opStatus != nullptr && opStatus[6-id] == '1';
     
     x *= 25;
     x += 3;

--- a/Source/AlgoDisplay.h
+++ b/Source/AlgoDisplay.h
@@ -26,9 +26,9 @@
 class AlgoDisplay : public Component {
     void displayOp(Graphics &g, char id, int x, int y, char link, char fb);
 public:
-    const char *opStatus;
+    const char *opStatus = nullptr;
     AlgoDisplay();
-    char *algo;
+    char *algo = nullptr;
     void paint(Graphics &g);
 };
 

--- a/Source/EngineMkI.cpp
+++ b/Source/EngineMkI.cpp
@@ -221,22 +221,23 @@ void EngineMkI::compute_fb2(int32_t *output, FmOpParams *parms, int32_t gain01, 
     gain[1] = parms[1].gain_out == 0 ? (ENV_MAX-1) : parms[1].gain_out;
 
     dgain[0] = (gain02 - gain01 + (N >> 1)) >> LG_N;
-    dgain[1] = (parms[1].gain_out - (parms[1].gain_out == 0 ? (ENV_MAX-1) : parms[1].gain_out));
-    
+    int32_t newgain1 = parms[1].gain_out == 0 ? (ENV_MAX-1) : parms[1].gain_out;
+    dgain[1] = (newgain1 - gain[1] + (N >> 1)) >> LG_N;
+
     for (int i = 0; i < N; i++) {
         int32_t scaled_fb = (y0 + y) >> (fb_shift + 1);
-        
+
         // op 0
         gain[0] += dgain[0];
         y0 = y;
         y = mkiSin(phase[0]+scaled_fb, gain[0]);
         phase[0] += parms[0].freq;
-        
+
         // op 1
         gain[1] += dgain[1];
         y = mkiSin(phase[1]+y, gain[1]);
         phase[1] += parms[1].freq;
-        
+
         output[i] = y;
     }
     fb_buf[0] = y0;
@@ -263,8 +264,10 @@ void EngineMkI::compute_fb3(int32_t *output, FmOpParams *parms, int32_t gain01, 
     gain[2] = parms[2].gain_out == 0 ? (ENV_MAX-1) : parms[2].gain_out;
 
     dgain[0] = (gain02 - gain01 + (N >> 1)) >> LG_N;
-    dgain[1] = (parms[1].gain_out - (parms[1].gain_out == 0 ? (ENV_MAX-1) : parms[1].gain_out));
-    dgain[2] = (parms[2].gain_out - (parms[2].gain_out == 0 ? (ENV_MAX-1) : parms[2].gain_out));
+    int32_t newgain1 = parms[1].gain_out == 0 ? (ENV_MAX-1) : parms[1].gain_out;
+    int32_t newgain2 = parms[2].gain_out == 0 ? (ENV_MAX-1) : parms[2].gain_out;
+    dgain[1] = (newgain1 - gain[1] + (N >> 1)) >> LG_N;
+    dgain[2] = (newgain2 - gain[2] + (N >> 1)) >> LG_N;
     
     
     for (int i = 0; i < N; i++) {

--- a/Source/GlobalEditor.cpp
+++ b/Source/GlobalEditor.cpp
@@ -403,6 +403,14 @@ GlobalEditor::GlobalEditor ()
 
     randomButton->setBounds (319, 109, 50, 30);
 
+    rndPrevButton.reset (new juce::TextButton ("rndPrevButton"));
+    addAndMakeVisible (rndPrevButton.get());
+    rndPrevButton->setExplicitFocusOrder (6);
+    rndPrevButton->setButtonText (TRANS ("PREV"));
+    rndPrevButton->addListener (this);
+
+    rndPrevButton->setBounds (368, 109, 50, 30);
+
     monoMode.reset (new juce::ToggleButton ("monoMode"));
     addAndMakeVisible (monoMode.get());
     monoMode->setExplicitFocusOrder (10);
@@ -508,6 +516,7 @@ GlobalEditor::~GlobalEditor()
     cartButton = nullptr;
     storeButton = nullptr;
     randomButton = nullptr;
+    rndPrevButton = nullptr;
     monoMode = nullptr;
     lfoType = nullptr;
     programSelector = nullptr;
@@ -705,6 +714,11 @@ void GlobalEditor::buttonClicked (juce::Button* buttonThatWasClicked)
     else if (buttonThatWasClicked == randomButton.get())
     {
         processor->randomizeVoice();
+        editor->updateUI();
+    }
+    else if (buttonThatWasClicked == rndPrevButton.get())
+    {
+        processor->undoRandomize();
         editor->updateUI();
     }
     else if (buttonThatWasClicked == monoMode.get())

--- a/Source/GlobalEditor.cpp
+++ b/Source/GlobalEditor.cpp
@@ -395,6 +395,14 @@ GlobalEditor::GlobalEditor ()
 
     storeButton->setBounds (270, 109, 50, 30);
 
+    randomButton.reset (new juce::TextButton ("randomButton"));
+    addAndMakeVisible (randomButton.get());
+    randomButton->setExplicitFocusOrder (5);
+    randomButton->setButtonText (TRANS ("RND"));
+    randomButton->addListener (this);
+
+    randomButton->setBounds (319, 109, 50, 30);
+
     monoMode.reset (new juce::ToggleButton ("monoMode"));
     addAndMakeVisible (monoMode.get());
     monoMode->setExplicitFocusOrder (10);
@@ -499,6 +507,7 @@ GlobalEditor::~GlobalEditor()
     parmButton = nullptr;
     cartButton = nullptr;
     storeButton = nullptr;
+    randomButton = nullptr;
     monoMode = nullptr;
     lfoType = nullptr;
     programSelector = nullptr;
@@ -692,6 +701,11 @@ void GlobalEditor::buttonClicked (juce::Button* buttonThatWasClicked)
         //[UserButtonCode_storeButton] -- add your button handler code here..
         editor->storeProgram();
         //[/UserButtonCode_storeButton]
+    }
+    else if (buttonThatWasClicked == randomButton.get())
+    {
+        processor->randomizeVoice();
+        editor->updateUI();
     }
     else if (buttonThatWasClicked == monoMode.get())
     {

--- a/Source/GlobalEditor.h
+++ b/Source/GlobalEditor.h
@@ -118,6 +118,7 @@ private:
     std::unique_ptr<juce::TextButton> parmButton;
     std::unique_ptr<juce::TextButton> cartButton;
     std::unique_ptr<juce::TextButton> storeButton;
+    std::unique_ptr<juce::TextButton> randomButton;
     std::unique_ptr<juce::ToggleButton> monoMode;
     std::unique_ptr<ComboBoxImage> lfoType;
     std::unique_ptr<ProgramSelector> programSelector;

--- a/Source/GlobalEditor.h
+++ b/Source/GlobalEditor.h
@@ -119,6 +119,7 @@ private:
     std::unique_ptr<juce::TextButton> cartButton;
     std::unique_ptr<juce::TextButton> storeButton;
     std::unique_ptr<juce::TextButton> randomButton;
+    std::unique_ptr<juce::TextButton> rndPrevButton;
     std::unique_ptr<juce::ToggleButton> monoMode;
     std::unique_ptr<ComboBoxImage> lfoType;
     std::unique_ptr<ProgramSelector> programSelector;

--- a/Source/OperatorEditor.cpp
+++ b/Source/OperatorEditor.cpp
@@ -630,7 +630,8 @@ void OperatorEditor::mouseDown(const MouseEvent &event) {
             break;
 
             case 5:
-                auto *editor = dynamic_cast<DexedAudioProcessorEditor*>(getParentComponent()->getParentComponent());
+                auto *parent = getParentComponent();
+                auto *editor = parent != nullptr ? dynamic_cast<DexedAudioProcessorEditor*>(parent->getParentComponent()) : nullptr;
                 if ( editor != nullptr ) {
                     editor->resetZoomFactor();
                 }

--- a/Source/PluginData.cpp
+++ b/Source/PluginData.cpp
@@ -664,3 +664,199 @@ void DexedAudioProcessor::resolvAppDir() {
         delete builtin_pgm;
     }
 }
+
+// ============================================================================
+// 4-operator sysex import (DX21/DX27/DX100/TX81Z)
+// ============================================================================
+
+// DX100 frequency ratio lookup table (64 entries, index 0-63)
+static const float dx100_ratios[] = {
+    0.50f,  0.71f,  0.78f,  0.87f,  1.00f,  1.41f,  1.57f,  1.73f,
+    2.00f,  2.82f,  3.00f,  3.14f,  3.46f,  4.00f,  4.24f,  4.71f,
+    5.00f,  5.19f,  5.65f,  6.00f,  6.28f,  6.92f,  7.00f,  7.07f,
+    7.85f,  8.00f,  8.48f,  8.65f,  9.00f,  9.42f,  9.89f, 10.00f,
+   10.38f, 10.99f, 11.00f, 11.30f, 12.00f, 12.11f, 12.56f, 12.72f,
+   13.00f, 13.84f, 14.00f, 14.10f, 14.13f, 15.00f, 15.55f, 15.37f,
+   15.70f, 16.96f, 17.27f, 17.30f, 18.37f, 18.84f, 19.03f, 19.78f,
+   20.41f, 20.76f, 21.20f, 21.98f, 22.49f, 23.53f, 24.22f, 25.95f
+};
+
+// Map 4-op algorithm (0-7) to DX7 algorithm (0-31)
+// 4-op algo 1-8 maps to DX7 algo 1,14,8,7,5,22,31,32 (zero-indexed below)
+static const uint8_t algo4to6[] = { 0, 13, 7, 6, 4, 21, 30, 31 };
+
+// Convert a 4-op frequency ratio index to DX7 coarse + fine
+static void ratioToDx7Freq(int ratioIdx, uint8_t &coarse, uint8_t &fine) {
+    if (ratioIdx < 0 || ratioIdx >= 64) {
+        coarse = 1;
+        fine = 0;
+        return;
+    }
+    float ratio = dx100_ratios[ratioIdx];
+
+    // DX7 coarse: 0 = 0.5, 1-31 = integer ratio
+    if (ratio < 0.75f) {
+        coarse = 0;  // 0.5 ratio
+        fine = 0;
+    } else {
+        coarse = (uint8_t)juce::jlimit(1, 31, (int)roundf(ratio));
+        // Fine tunes the ratio: freq = coarse * (1 + fine/100)
+        // So fine = ((ratio / coarse) - 1) * 100
+        if (coarse > 0) {
+            float fineF = (ratio / (float)coarse - 1.0f) * 100.0f;
+            fine = (uint8_t)juce::jlimit(0, 99, (int)roundf(fineF));
+        } else {
+            fine = 0;
+        }
+    }
+}
+
+int Cartridge::load4opSysex(const uint8_t *data4op, int size) {
+    // Validate minimum size: 6 header + 4096 data + checksum + F7
+    if (size < 4104) {
+        TRACE("4-op sysex too small: %d bytes", size);
+        return 2;
+    }
+
+    const uint8_t *voices4op = data4op + 6;  // skip 6-byte header
+
+    // Build DX7 cartridge: 32 voices × 128 bytes packed
+    uint8_t dx7packed[4096];
+    memset(dx7packed, 0, 4096);
+
+    for (int v = 0; v < 32; v++) {
+        const uint8_t *src = voices4op + (v * 128);
+        uint8_t *dst = dx7packed + (v * 128);
+
+        // ---- Convert 4 operators ----
+        // 4-op order in sysex: op4(bytes 0-9), op3(10-19), op2(20-29), op1(30-39)
+        // DX7 packed order: op6(bytes 0-16), op5(17-33), op4(34-50), op3(51-67), op2(68-84), op1(85-101)
+        // We map 4-op op4→DX7 op4, op3→op3, op2→op2, op1→op1
+        // DX7 op6 and op5 are left silent (output level = 0)
+
+        for (int op4idx = 0; op4idx < 4; op4idx++) {
+            const uint8_t *opsrc = src + (op4idx * 10);
+
+            // 4-op operators are in order op4,op3,op2,op1 (indices 0,1,2,3)
+            // Map to DX7 operators: op4→DX7_op4(idx 2), op3→DX7_op3(idx 3), op2→DX7_op2(idx 4), op1→DX7_op1(idx 5)
+            int dx7opIdx = op4idx + 2;  // skip op6(0) and op5(1)
+            uint8_t *opdst = dst + (dx7opIdx * 17);
+
+            // Scale envelope rates from 4-op range (0-31) to DX7 range (0-99)
+            uint8_t ar  = (uint8_t)juce::jlimit(0, 99, (int)(opsrc[0] * 99 / 31));
+            uint8_t d1r = (uint8_t)juce::jlimit(0, 99, (int)(opsrc[1] * 99 / 31));
+            uint8_t d2r = (uint8_t)juce::jlimit(0, 99, (int)(opsrc[2] * 99 / 31));
+            uint8_t rr  = (uint8_t)juce::jlimit(0, 99, (int)(opsrc[3] * 99 / 15));
+            uint8_t d1l = (uint8_t)juce::jlimit(0, 99, (int)(opsrc[4] * 99 / 15));
+
+            // DX7 packed operator format (17 bytes):
+            // 0-3: EG rates R1-R4
+            opdst[0] = ar;    // R1 = attack
+            opdst[1] = d1r;   // R2 = decay1
+            opdst[2] = d2r;   // R3 = decay2
+            opdst[3] = rr;    // R4 = release
+            // 4-7: EG levels L1-L4
+            opdst[4] = 99;    // L1 = attack peak
+            opdst[5] = d1l;   // L2 = decay1 level (sustain)
+            opdst[6] = d1l;   // L3 = sustain level (same as D1L)
+            opdst[7] = 0;     // L4 = release end
+
+            // 8: keyboard level scaling break point
+            opdst[8] = 39;  // C3 (middle of keyboard)
+            // 9-10: scaling left/right depth
+            opdst[9] = 0;
+            opdst[10] = 0;
+
+            // 11: left curve (bits 0-1) | right curve (bits 2-3)
+            opdst[11] = 0;
+
+            // 12: detune (bits 3-6) | rate scaling (bits 0-2)
+            uint8_t rs_dbt = opsrc[9];
+            uint8_t rateScaling = (rs_dbt >> 3) & 0x03;
+            uint8_t detune4op = rs_dbt & 0x07;
+            // 4-op detune is 0-6 (center=3), DX7 detune is 0-14 (center=7)
+            uint8_t detune7 = (uint8_t)juce::jlimit(0, 14, (int)(detune4op * 2 + 1));
+            opdst[12] = (detune7 << 3) | rateScaling;
+
+            // 13: key velocity sensitivity (bits 2-4) | amp mod sensitivity (bits 0-1)
+            uint8_t ame_ebs_kvs = opsrc[6];
+            uint8_t kvs = ame_ebs_kvs & 0x07;
+            uint8_t ams = (ame_ebs_kvs >> 6) & 0x01;  // amp mod enable → sensitivity
+            opdst[13] = (kvs << 2) | ams;
+
+            // 14: output level (0-99)
+            opdst[14] = opsrc[7];
+
+            // 15: freq coarse (bits 1-5) | osc mode (bit 0)
+            uint8_t coarse, fine;
+            ratioToDx7Freq(opsrc[8], coarse, fine);
+            opdst[15] = (coarse << 1) | 0;  // mode 0 = ratio
+
+            // 16: freq fine (0-99)
+            opdst[16] = fine;
+        }
+
+        // ---- Set DX7 op6 and op5 to silent ----
+        for (int silentOp = 0; silentOp < 2; silentOp++) {
+            uint8_t *opdst = dst + (silentOp * 17);
+            // Fast decay, zero output
+            opdst[0] = 99; opdst[1] = 99; opdst[2] = 99; opdst[3] = 99;
+            opdst[4] = 99; opdst[5] = 99; opdst[6] = 99; opdst[7] = 0;
+            opdst[8] = 39; // break point
+            opdst[14] = 0; // output level = 0 (silent)
+            opdst[15] = 2; // coarse = 1, ratio mode
+            opdst[12] = (7 << 3); // detune = 7 (center)
+        }
+
+        // ---- Global voice parameters ----
+        uint8_t sy_fbl_alg = src[40];
+        uint8_t algorithm4op = sy_fbl_alg & 0x07;
+        uint8_t feedback = (sy_fbl_alg >> 3) & 0x07;
+
+        // Pitch EG (bytes 102-109 in DX7 packed)
+        // 4-op synths don't have per-voice pitch EG, set flat
+        dst[102] = 50; dst[103] = 50; dst[104] = 50; dst[105] = 50; // rates
+        dst[106] = 50; dst[107] = 50; dst[108] = 50; dst[109] = 50; // levels
+
+        // Algorithm + osc key sync (byte 110)
+        dst[110] = algo4to6[algorithm4op & 0x07];
+
+        // Feedback + osc sync (byte 111)
+        uint8_t oscSync = (sy_fbl_alg >> 6) & 0x01;
+        dst[111] = (oscSync << 3) | feedback;
+
+        // LFO parameters
+        dst[112] = src[41]; // LFO speed (0-99)
+        dst[113] = src[42]; // LFO delay (0-99)
+        dst[114] = src[43]; // LFO pitch mod depth (0-99)
+        dst[115] = src[44]; // LFO amp mod depth (0-99)
+
+        // LFO PMS | wave | sync (byte 116)
+        uint8_t pms_ams_lfw = src[45];
+        uint8_t lfoWave = pms_ams_lfw & 0x03;
+        uint8_t pitchModSens = (pms_ams_lfw >> 4) & 0x07;
+        // DX7 byte 116: LPMS(bits 4-6) | LFW(bits 1-3) | LKS(bit 0)
+        dst[116] = (pitchModSens << 4) | (lfoWave << 1) | 0;
+
+        // Transpose (byte 117)
+        // 4-op transpose: 0-48 (24=C3), same as DX7
+        dst[117] = src[46];
+
+        // Voice name (bytes 118-127)
+        // 4-op name starts at src[57] for 10 bytes
+        for (int i = 0; i < 10; i++) {
+            uint8_t c = (i + 57 < 128) ? src[57 + i] : ' ';
+            dst[118 + i] = c & 0x7F;
+        }
+    }
+
+    // Store as DX7 cartridge
+    uint8_t header[] = SYSEX_HEADER;
+    memcpy(voiceData, header, 6);
+    memcpy(voiceData + 6, dx7packed, 4096);
+    voiceData[4102] = sysexChecksum(voiceData + 6, 4096);
+    voiceData[4103] = 0xF7;
+
+    TRACE("4-op to DX7 conversion complete");
+    return 0;
+}

--- a/Source/PluginData.cpp
+++ b/Source/PluginData.cpp
@@ -335,6 +335,27 @@ void DexedAudioProcessor::randomizeVoice() {
     for (int i = 0; i < 6; i++)
         data[149 + i] = nameChars[rng.nextInt(36)];
 
+    // Save to history before applying
+    if (rndHistoryCount < RND_HISTORY_SIZE) {
+        rndHistoryPos = rndHistoryCount++;
+    } else {
+        // Shift history, drop oldest
+        for (int i = 0; i < RND_HISTORY_SIZE - 1; i++)
+            memcpy(rndHistory[i], rndHistory[i + 1], 161);
+        rndHistoryPos = RND_HISTORY_SIZE - 1;
+    }
+    memcpy(rndHistory[rndHistoryPos], data, 161);
+
+    unpackOpSwitch(0x3F);
+    panic();
+    lfo.reset(data + 137);
+    triggerAsyncUpdate();
+}
+
+void DexedAudioProcessor::undoRandomize() {
+    if (rndHistoryPos <= 0) return;
+    rndHistoryPos--;
+    memcpy(data, rndHistory[rndHistoryPos], 161);
     unpackOpSwitch(0x3F);
     panic();
     lfo.reset(data + 137);

--- a/Source/PluginData.cpp
+++ b/Source/PluginData.cpp
@@ -122,7 +122,8 @@ void Cartridge::unpackProgram(uint8_t *unpackPgm, int idx) {
             unpackPgm[op * 21 + i] = normparm(currparm, 99, i);
         }
         
-        memcpy(unpackPgm + op * 21, bulk + op * 17, 11);
+        // Note: the memcpy that was here has been removed — it was overwriting
+        // the normalized values computed by the loop above with raw unnormalized data.
         char leftrightcurves = bulk[op * 17 + 11]&0xF; // bits 4-7 don't care per sysex spec
         unpackPgm[op * 21 + 11] = leftrightcurves & 3;
         unpackPgm[op * 21 + 12] = (leftrightcurves >> 2) & 3;
@@ -211,8 +212,8 @@ void DexedAudioProcessor::setupStartupCart() {
     ZipFile *builtin_pgm = new ZipFile(mis, true);
     InputStream *is = builtin_pgm->createStreamForEntry(builtin_pgm->getIndexOfFileName(("Dexed_01.syx")));
     Cartridge init;
-    
-    if ( init.load(*is) != -1 ) {
+
+    if ( is != nullptr && init.load(*is) != -1 ) {
         loadCartridge(init);
     }
 
@@ -293,6 +294,7 @@ void DexedAudioProcessor::sendSysexCartridge(File cart) {
         AlertWindow::showMessageBoxAsync (AlertWindow::WarningIcon,
                                           "Error",
                                           "Unable to open: " + f);
+        return;
     }
     
     uint8 syx_data[65535];
@@ -397,6 +399,7 @@ void DexedAudioProcessor::setStateInformation(const void* source, int sizeInByte
         strcpy(controllers.opSwitch, "111111");
     } else {
         strncpy(controllers.opSwitch, opSwitchValue.toRawUTF8(), 6);
+        controllers.opSwitch[6] = '\0';
     }
     
     controllers.wheel.parseConfig(root->getStringAttribute("wheelMod").toRawUTF8());
@@ -412,7 +415,7 @@ void DexedAudioProcessor::setStateInformation(const void* source, int sizeInByte
     controllers.mpePitchBendRange = ( root->getIntAttribute("mpePitchBendRange", 24) );
     controllers.mpeEnabled = ( root->getIntAttribute("mpeEnabled", 0) != 0 );
 
-    controllers.portamento_cc = ( root->getIntAttribute("portamento", 0) );
+    controllers.portamento_cc = juce::jlimit(0, 127, root->getIntAttribute("portamento", 0));
     controllers.portamento_enable_cc = controllers.portamento_cc > 1;
     controllers.portamento_gliss_cc = ( root->getIntAttribute("glissando", 0) );
     controllers.refresh();

--- a/Source/PluginData.cpp
+++ b/Source/PluginData.cpp
@@ -240,6 +240,107 @@ void DexedAudioProcessor::resetToInitVoice() {
     triggerAsyncUpdate();
 }
 
+void DexedAudioProcessor::randomizeVoice() {
+    auto& rng = juce::Random::getSystemRandom();
+
+    // Musically useful coarse frequency ratios (harmonics and common sub-ratios)
+    // These produce tonal results rather than dissonant noise
+    const int usefulCoarse[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 12, 16 };
+    const int numUsefulCoarse = 12;
+
+    // Per-operator parameters (6 operators, 21 bytes each)
+    for (int op = 0; op < 6; op++) {
+        int off = op * 21;
+
+        // EG rates 1-4 (0-99) — slower overall for more pad-like sounds
+        data[off + 0] = 20 + rng.nextInt(60);       // R1 (attack): varied, some slow
+        data[off + 1] = 10 + rng.nextInt(35);        // R2 (decay): slow-moderate
+        data[off + 2] = 5 + rng.nextInt(25);         // R3 (sustain): slow
+        data[off + 3] = 10 + rng.nextInt(40);        // R4 (release): slow-moderate
+
+        // EG levels 1-4 (0-99) — high sustain for pad-like tails
+        data[off + 4] = 90 + rng.nextInt(10);        // L1: near max (attack peak)
+        data[off + 5] = 70 + rng.nextInt(29);        // L2: high
+        data[off + 6] = 60 + rng.nextInt(35);        // L3: sustain level — high for pads
+        data[off + 7] = 0;                            // L4: zero (silence at release end)
+
+        // Keyboard level scaling break point (0-99) — center around middle C
+        data[off + 8] = 27 + rng.nextInt(30);
+        // Left/right depth (0-99) — keep subtle
+        data[off + 9] = rng.nextInt(40);
+        data[off + 10] = rng.nextInt(40);
+        // Left/right curve (0-3)
+        data[off + 11] = rng.nextInt(4);
+        data[off + 12] = rng.nextInt(4);
+        // Keyboard rate scaling (0-7) — keep low
+        data[off + 13] = rng.nextInt(4);
+        // Amp mod sensitivity (0-3)
+        data[off + 14] = rng.nextInt(4);
+        // Key velocity sensitivity (0-7)
+        data[off + 15] = 2 + rng.nextInt(5);
+        // Output level (0-99) — bias toward audible
+        data[off + 16] = 60 + rng.nextInt(40);
+        // Osc mode: almost always ratio (0), rarely fixed (1)
+        data[off + 17] = rng.nextInt(20) < 1 ? 1 : 0;
+        // Freq coarse — use musically useful ratios
+        data[off + 18] = usefulCoarse[rng.nextInt(numUsefulCoarse)];
+        // Freq fine (0-99) — keep low for more tonal results
+        data[off + 19] = rng.nextInt(30);
+        // Detune (0-14, center=7) — subtle detune around center
+        data[off + 20] = 5 + rng.nextInt(5);
+    }
+
+    // Ensure carriers have good output levels and modulators are varied
+    // Op6 (index 5) is a carrier in most algorithms
+    data[5 * 21 + 16] = 80 + rng.nextInt(20);
+    // Some modulators can be quieter for subtlety
+    for (int op = 0; op < 4; op++) {
+        if (rng.nextInt(3) == 0)
+            data[op * 21 + 16] = 30 + rng.nextInt(50);
+    }
+
+    // Pitch EG rates (0-99) — fast so pitch settles quickly
+    for (int i = 126; i < 130; i++)
+        data[i] = 70 + rng.nextInt(25);
+    // Pitch EG levels (0-99) — flat at 50 = no pitch shift
+    for (int i = 130; i < 134; i++)
+        data[i] = 50;
+
+    // Algorithm (0-31)
+    data[134] = rng.nextInt(32);
+    // Feedback (0-7) — keep moderate to avoid harsh distortion
+    data[135] = rng.nextInt(5);
+    // Oscillator sync (0-1)
+    data[136] = rng.nextInt(2);
+    // LFO speed (0-99) — slow for gentle movement
+    data[137] = rng.nextInt(35);
+    // LFO delay (0-99) — some delay before LFO kicks in
+    data[138] = 20 + rng.nextInt(60);
+    // LFO pitch mod depth (0-99) — very subtle, no heavy vibrato
+    data[139] = rng.nextInt(10);
+    // LFO amp mod depth (0-99) — subtle tremolo
+    data[140] = rng.nextInt(20);
+    // LFO sync (0-1)
+    data[141] = rng.nextInt(2);
+    // LFO waveform (0-5) — favor sine(4) and triangle(0) for smooth movement
+    data[142] = rng.nextInt(3) == 0 ? rng.nextInt(6) : (rng.nextInt(2) == 0 ? 0 : 4);
+    // Pitch mod sensitivity (0-7) — very low to minimize vibrato
+    data[143] = rng.nextInt(2);
+    // Transpose (0-48, center=24 is C3)
+    data[144] = 24;
+
+    // Voice name: "RND-" + 6 random chars
+    const char* nameChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+    data[145] = 'R'; data[146] = 'N'; data[147] = 'D'; data[148] = '-';
+    for (int i = 0; i < 6; i++)
+        data[149 + i] = nameChars[rng.nextInt(36)];
+
+    unpackOpSwitch(0x3F);
+    panic();
+    lfo.reset(data + 137);
+    triggerAsyncUpdate();
+}
+
 void DexedAudioProcessor::copyToClipboard(int srcOp) {
     DexedClipboard clipboard(data + (srcOp *21), 21);
     clipboard.write(String("Program: '") + getProgramName(getCurrentProgram()) + "' operator: " + String(6-srcOp));

--- a/Source/PluginData.h
+++ b/Source/PluginData.h
@@ -129,6 +129,13 @@ public:
         if ( size > 65535 )
             size = 65535;
         
+        // Check for 4-operator sysex (DX21/DX27/DX100/TX81Z)
+        // Format: F0 43 0x 04 20 00 ... (format number 0x04 = 4-op 32-voice bulk)
+        if (size >= 4104 && pos[0] == 0xF0 && pos[1] == 0x43 && pos[3] == 0x04) {
+            TRACE("detected 4-operator sysex, converting to DX7 format");
+            return load4opSysex(pos, size);
+        }
+
         // we loop until we find something that looks like a DX7 cartridge (based on size)
         while(size >= 4104) {
             // it was a sysex first, now random data; return random
@@ -137,7 +144,7 @@ public:
                 TRACE("stream was a sysex, but not anymore rc=2");
                 return 2;
             }
-            
+
             // check if this is the size of a DX7 sysex cartridge
             for(int i=0;i<size;i++) {
                 if ( pos[i] == 0xF7 ) {
@@ -253,6 +260,13 @@ public:
 
     void unpackProgram(uint8_t *unpackPgm, int idx);
     void packProgram(uint8_t *src, int idx, String name, char *opSwitch);
+
+    /**
+     * Convert a 4-operator sysex cartridge (DX21/DX27/DX100/TX81Z)
+     * into DX7-compatible 6-operator format.
+     * Returns 0 on success, non-zero on failure.
+     */
+    int load4opSysex(const uint8_t *data4op, int size);
 };
 
 class DexedClipboard {

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -98,6 +98,38 @@ DexedAudioProcessorEditor::DexedAudioProcessorEditor (DexedAudioProcessor* owner
     AffineTransform scale = AffineTransform::scale(processor->getZoomFactor());
     frameComponent.setTransform(scale);
     resetSize();
+
+    // Set up resizable window with aspect ratio constraint
+    float baseH = processor->showKeyboard ? WINDOW_SIZE_Y : WINDOW_SIZE_Y - 94;
+    float aspectRatio = (float)WINDOW_SIZE_X / baseH;
+    constrainer.setFixedAspectRatio(aspectRatio);
+    constrainer.setMinimumSize(WINDOW_SIZE_X / 2, (int)(baseH / 2));
+
+    // Compute max size from screen height (the limiting dimension on wide monitors)
+    auto* display = Desktop::getInstance().getDisplays().getPrimaryDisplay();
+    if (display != nullptr) {
+        int screenH = display->userArea.getHeight();
+        int titleBarH = 28; // approximate JUCE title bar height
+        int availH = screenH - titleBarH;
+        int maxW = (int)(availH * aspectRatio);
+        // Also don't exceed screen width
+        int screenW = display->userArea.getWidth();
+        if (maxW > screenW) {
+            maxW = screenW;
+            availH = (int)(maxW / aspectRatio);
+        }
+        constrainer.setMaximumSize(maxW, availH);
+    } else {
+        constrainer.setMaximumSize(WINDOW_SIZE_X * 4, (int)(baseH * 4));
+    }
+    setConstrainer(&constrainer);
+
+    resizableCorner = std::make_unique<ResizableCornerComponent>(this, &constrainer);
+    addAndMakeVisible(resizableCorner.get());
+    resizableCorner->setAlwaysOnTop(true);
+
+    setResizable(true, false);
+
     addKeyListener(this);
     updateUI();
     startTimer(100);
@@ -113,6 +145,17 @@ DexedAudioProcessorEditor::~DexedAudioProcessorEditor() {
 void DexedAudioProcessorEditor::paint (Graphics& g) {
     g.setColour(background);
     g.fillRoundedRectangle(0.0f, 0.0f, (float) getWidth(), (float) getHeight(), 0);
+}
+
+void DexedAudioProcessorEditor::resized() {
+    float baseH = processor->showKeyboard ? WINDOW_SIZE_Y : WINDOW_SIZE_Y - 94;
+    float factor = (float)getWidth() / (float)WINDOW_SIZE_X;
+
+    processor->setZoomFactor(factor);
+    frameComponent.setTransform(AffineTransform::scale(factor));
+
+    if (resizableCorner != nullptr)
+        resizableCorner->setBounds(getWidth() - 16, getHeight() - 16, 16, 16);
 }
 
 void DexedAudioProcessorEditor::cartShow() {
@@ -260,6 +303,15 @@ void DexedAudioProcessorEditor::comboBoxChanged (ComboBox* comboBoxThatHasChange
 }
 
 void DexedAudioProcessorEditor::timerCallback() {
+    // Configure standalone window for resizing (once, when parent is available)
+    if (!titleBarConfigured) {
+        if (auto* topLevel = findParentComponentOfClass<DocumentWindow>()) {
+            topLevel->setResizable(true, false);
+            topLevel->setConstrainer(&constrainer);
+            titleBarConfigured = true;
+        }
+    }
+
     if ( processor->forceRefreshUI ) {
         processor->forceRefreshUI = false;
         updateUI();

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -568,14 +568,14 @@ void DexedAudioProcessorEditor::filesDropped (const StringArray &files, int x, i
         if (fn.endsWithIgnoreCase(".scl"))
         {
             if (filesize == 0) {
-                AlertWindow::showMessageBox(
+                AlertWindow::showMessageBoxAsync(
                     AlertWindow::WarningIcon,
                     "File size error!",
                     "File \'" + fn.toStdString() + "\' is empty."
                 );
             }
             else if (filesize > MAX_SCL_KBM_FILE_SIZE) {
-                AlertWindow::showMessageBox(
+                AlertWindow::showMessageBoxAsync(
                     AlertWindow::WarningIcon,
                     "File size error!",
                     "File \'" + fn.toStdString() + "\' has " + std::to_string(filesize) + " bytes, exceeding the maximum limit ("+std::to_string(MAX_SCL_KBM_FILE_SIZE)+")."
@@ -588,14 +588,14 @@ void DexedAudioProcessorEditor::filesDropped (const StringArray &files, int x, i
         if (fn.endsWithIgnoreCase(".kbm"))
         {
             if (filesize == 0) {
-                AlertWindow::showMessageBox(
+                AlertWindow::showMessageBoxAsync(
                     AlertWindow::WarningIcon,
                     "File size error!",
                     "File \'" + fn.toStdString() + "\' is empty."
                 );
             }
             else if (filesize > MAX_SCL_KBM_FILE_SIZE) {
-                AlertWindow::showMessageBox(
+                AlertWindow::showMessageBoxAsync(
                     AlertWindow::WarningIcon,
                     "File size error!",
                     "File \'" + fn.toStdString() + "\' has " + std::to_string(filesize) + " bytes, exceeding the maximum limit (" + std::to_string(MAX_SCL_KBM_FILE_SIZE) + ")."

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -317,6 +317,12 @@ void DexedAudioProcessorEditor::timerCallback() {
         updateUI();
     }
 
+    // Poll for CC changes from audio thread (replaces unsafe Value::setValue on audio thread)
+    int pendingCC = processor->pendingCCValue.exchange(-1, std::memory_order_relaxed);
+    if (pendingCC >= 0) {
+        processor->lastCCUsed.setValue(pendingCC);
+    }
+
     if ( ! processor->peekVoiceStatus() )
         return;
 
@@ -545,7 +551,7 @@ bool DexedAudioProcessorEditor::isInterestedInFileDrag (const StringArray &files
 
     for( auto i = files.begin(); i != files.end(); ++i )
     {
-        if( i->endsWithIgnoreCase( ".scl" ) || i->endsWithIgnoreCase( ".kbm" ) )
+        if( i->endsWithIgnoreCase( ".scl" ) || i->endsWithIgnoreCase( ".kbm" ) || i->endsWithIgnoreCase( ".syx" ) )
             return true;
     }
     return false;
@@ -597,6 +603,10 @@ void DexedAudioProcessorEditor::filesDropped (const StringArray &files, int x, i
             else {
                 processor->applyKBMMapping(File(fn));
             }
+        }
+        if (fn.endsWithIgnoreCase(".syx"))
+        {
+            loadCart(File(fn));
         }
     }
     catch (const std::ios_base::failure& ex) {

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -148,10 +148,12 @@ void DexedAudioProcessorEditor::paint (Graphics& g) {
 }
 
 void DexedAudioProcessorEditor::resized() {
-    float baseH = processor->showKeyboard ? WINDOW_SIZE_Y : WINDOW_SIZE_Y - 94;
     float factor = (float)getWidth() / (float)WINDOW_SIZE_X;
 
-    processor->setZoomFactor(factor);
+    if (std::abs(factor - processor->getZoomFactor()) > 0.001f) {
+        processor->setZoomFactor(factor);
+        processor->savePreference();
+    }
     frameComponent.setTransform(AffineTransform::scale(factor));
 
     if (resizableCorner != nullptr)
@@ -307,7 +309,6 @@ void DexedAudioProcessorEditor::timerCallback() {
     if (!titleBarConfigured) {
         if (auto* topLevel = findParentComponentOfClass<DocumentWindow>()) {
             topLevel->setResizable(true, false);
-            topLevel->setConstrainer(&constrainer);
             titleBarConfigured = true;
         }
     }

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -666,6 +666,18 @@ bool DexedAudioProcessorEditor::keyPressed(const KeyPress& key, Component* origi
         return true;
     }
 
+    if ( keycode == 'R' && mods.isCtrlDown() ) {
+        processor->randomizeVoice();
+        updateUI();
+        return true;
+    }
+
+    if ( keycode == 'Z' && mods.isCtrlDown() ) {
+        processor->undoRandomize();
+        updateUI();
+        return true;
+    }
+
     if ( key.getKeyCode() == KeyPress::escapeKey ) {
         cartManager.hideCartridgeManager();
         return true;

--- a/Source/PluginEditor.h
+++ b/Source/PluginEditor.h
@@ -41,6 +41,10 @@ class DexedAudioProcessorEditor  : public AudioProcessorEditor, public ComboBox:
     Component cartManagerCover;
 
     SharedResourcePointer<DXLookNFeel> lookAndFeel;
+    ComponentBoundsConstrainer constrainer;
+    std::unique_ptr<ResizableCornerComponent> resizableCorner;
+    bool titleBarConfigured = false;
+    juce::Rectangle<int> preMaximiseBounds;
     std::unique_ptr<juce::DialogWindow> dexedParameterDialog;
     #ifdef DEXED_EVENT_DEBUG
         FocusLogger focusLogger;
@@ -58,6 +62,7 @@ public:
     virtual void timerCallback() override;
 
     virtual void paint (Graphics& g) override;
+    virtual void resized() override;
     virtual void comboBoxChanged (ComboBox* comboBoxThatHasChanged) override;
     void updateUI();
     void rebuildProgramCombobox();

--- a/Source/PluginFx.cpp
+++ b/Source/PluginFx.cpp
@@ -101,6 +101,8 @@ inline float PluginFx::NR(float sample, float g) {
 }
 
 void PluginFx::process(float *work, int sampleSize) {
+    if (sampleSize == 0) return;
+
     // very basic DC filter
     float t_fd = work[0];
     work[0] = work[0] - dc_id + dc_r * dc_od;
@@ -173,6 +175,9 @@ void PluginFx::process(float *work, int sampleSize) {
                 break;
             case 3:
                 mc = y1;
+                break;
+            default:
+                mc = 0;
                 break;
         }
         

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -927,7 +927,7 @@ void DexedAudioProcessor::applySCLTuning() {
         // (reason: the extension ''.scl'' is mandatory according to 
         // ''https://www.huygens-fokker.org/scala/scl_format.html''
         if (s.getFileExtension() != ".scl") {
-            AlertWindow::showMessageBox(AlertWindow::WarningIcon, "Invalid file type!", "Only files with the \".scl\" extension (in lowercase!) are allowed.");
+            AlertWindow::showMessageBoxAsync(AlertWindow::WarningIcon, "Invalid file type!", "Only files with the \".scl\" extension (in lowercase!) are allowed.");
             continue;
         }
 
@@ -935,7 +935,7 @@ void DexedAudioProcessor::applySCLTuning() {
         if (s.getSize() > MAX_SCL_KBM_FILE_SIZE) {
             std::string msg;
             msg = "File size exceeded the maximum limit of " + std::to_string(MAX_SCL_KBM_FILE_SIZE) + " bytes.";
-            AlertWindow::showMessageBox(AlertWindow::WarningIcon, "File size error!", msg);
+            AlertWindow::showMessageBoxAsync(AlertWindow::WarningIcon, "File size error!", msg);
             continue;
         }
 
@@ -944,7 +944,7 @@ void DexedAudioProcessor::applySCLTuning() {
         if (s.getSize() == 0) {
             std::string msg;
             msg = "File is empty.";
-            AlertWindow::showMessageBox(AlertWindow::WarningIcon, "File size error!", msg);
+            AlertWindow::showMessageBoxAsync(AlertWindow::WarningIcon, "File size error!", msg);
             continue;
         }
 
@@ -1003,7 +1003,7 @@ void DexedAudioProcessor::applyKBMMapping() {
         // (reason: the extension ''.kbm'' is mandatory according to 
         // ''https://www.huygens-fokker.org/scala/scl_format.html''
         if (s.getFileExtension() != ".kbm") {
-            AlertWindow::showMessageBox(AlertWindow::WarningIcon, "Invalid file type!", "Only files with the \".kbm\" extension (in lowercase!) are allowed.");
+            AlertWindow::showMessageBoxAsync(AlertWindow::WarningIcon, "Invalid file type!", "Only files with the \".kbm\" extension (in lowercase!) are allowed.");
             continue;
         }
 
@@ -1011,7 +1011,7 @@ void DexedAudioProcessor::applyKBMMapping() {
         if (s.getSize() > MAX_SCL_KBM_FILE_SIZE) {
             std::string msg;
             msg = "File size exceeded the maximum limit of " + std::to_string(MAX_SCL_KBM_FILE_SIZE) + " bytes.";
-            AlertWindow::showMessageBox(AlertWindow::WarningIcon, "File size error!", msg);
+            AlertWindow::showMessageBoxAsync(AlertWindow::WarningIcon, "File size error!", msg);
             continue;
         }
 
@@ -1020,7 +1020,7 @@ void DexedAudioProcessor::applyKBMMapping() {
         if (s.getSize() == 0) {
             std::string msg;
             msg = "File is empty.";
-            AlertWindow::showMessageBox(AlertWindow::WarningIcon, "File size error!", msg);
+            AlertWindow::showMessageBoxAsync(AlertWindow::WarningIcon, "File size error!", msg);
             continue;
         }
 

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -714,7 +714,7 @@ void DexedAudioProcessor::handleIncomingMidiMessage(MidiInput* source, const Mid
             return;
             }
 
-            uint8 offset = (buf[3] << 7) + buf[4];
+            int offset = (buf[3] << 7) + buf[4];
             uint8 value = buf[5];
 
             TRACE("parameter change message offset:%d value:%d", offset, value);

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -294,16 +294,18 @@ void DexedAudioProcessor::processBlock(AudioSampleBuffer& buffer, MidiBuffer& mi
 
     fx.process(channelData, numSamples);
 
+    float vu = vuSignal.load(std::memory_order_relaxed);
     for(i=0; i<numSamples; i++) {
         float s = std::abs(channelData[i]);
 
-        if (s > vuSignal)
-            vuSignal = s;
-        else if (vuSignal > /*0.001f*/ 1.26E-4F) // 1.26E-4 is equivalent to -39 dB, the min amplitude associated to leftmost LED
-            vuSignal *= vuDecayFactor;
+        if (s > vu)
+            vu = s;
+        else if (vu > 1.26E-4F) // 1.26E-4 is equivalent to -39 dB, the min amplitude associated to leftmost LED
+            vu *= vuDecayFactor;
         else
-            vuSignal = 0;
+            vu = 0;
     }
+    vuSignal.store(vu, std::memory_order_relaxed);
     
     // DX7 is a mono synth, but copy it to the right channel is available
     if ( buffer.getNumChannels() > 1 )
@@ -440,8 +442,8 @@ void DexedAudioProcessor::processMidiMessage(const MidiMessage *msg) {
                         // event thread
                         linkedCtrl->publishValueAsync((float) value / 127);
                     }
-                    // this is used to notify the dialog that a CC value was received.
-                    lastCCUsed.setValue(channel_cc);
+                    // notify the UI that a CC value was received (polled by timer)
+                    pendingCCValue.store(channel_cc, std::memory_order_relaxed);
                 }
             }
             return;

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -235,6 +235,7 @@ public :
     const String getProgramName (int index) override;
     void changeProgramName(int index, const String& newName) override;
     void resetToInitVoice() ;
+    void randomizeVoice() ;
     
     //==============================================================================
     void getStateInformation (MemoryBlock& destData) override;

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -237,6 +237,12 @@ public :
     void changeProgramName(int index, const String& newName) override;
     void resetToInitVoice() ;
     void randomizeVoice() ;
+    void undoRandomize() ;
+
+    static const int RND_HISTORY_SIZE = 32;
+    uint8_t rndHistory[RND_HISTORY_SIZE][161];
+    int rndHistoryCount = 0;
+    int rndHistoryPos = -1;
     
     //==============================================================================
     void getStateInformation (MemoryBlock& destData) override;

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -31,6 +31,7 @@
 #include "msfa/synth.h"
 #include "msfa/fm_core.h"
 #include "msfa/tuning.h"
+#include <atomic>
 #include "PluginParam.h"
 #include "PluginData.h"
 #include "PluginFx.h"
@@ -99,7 +100,7 @@ class DexedAudioProcessor  : public AudioProcessor, public AsyncUpdater, public 
      * This flag is used in the audio thread to know if the voice has changed
      * and needs to be updated.
      */
-    bool refreshVoice;
+    std::atomic<bool> refreshVoice;
     bool normalizeDxVelocity;
     bool sendSysexChange;
     
@@ -144,8 +145,8 @@ public :
     VoiceStatus voiceStatus;
     File activeFileCartridge;
     
-    bool forceRefreshUI;
-    float vuSignal;
+    std::atomic<bool> forceRefreshUI;
+    std::atomic<float> vuSignal;
     double vuDecayFactor = 0.999361; // (for 48 kHz sampling rate)
     bool showKeyboard;
     int getEngineType();
@@ -253,6 +254,7 @@ public :
     static File dexedCartDir;
 
     Value lastCCUsed;
+    std::atomic<int> pendingCCValue{-1};  // set on audio thread, polled by UI
     int lastActiveVoice = 0;
 
     MTSClient *mtsClient;

--- a/Source/ProgramListBox.h
+++ b/Source/ProgramListBox.h
@@ -36,7 +36,7 @@ public:
 
 class ProgramLabel;
 class ProgramListBox : public Component, public KeyListener {
-    ProgramListBoxListener *listener;    
+    ProgramListBoxListener *listener = nullptr;
     Cartridge cartContent;
     std::unique_ptr<ProgramLabel> labels[32];
 

--- a/Source/VUMeter.cpp
+++ b/Source/VUMeter.cpp
@@ -144,7 +144,8 @@ int VuMeterBase::ampToStripeIndex_be(float amp) {
 // Paints a single stripe.
 void VuMeterBase::paint(Graphics& g) {
     int index = (this->*ampToStripeIndex)(v);
-    g.drawImageAt(*(singleStripes[index]), 0, 0); // it might be more efficient than the ``drawImage()``
+    if (singleStripes[index] != nullptr)
+        g.drawImageAt(*(singleStripes[index]), 0, 0);
 }
 
 // Calculates amplitude value from the traditional decibel (based on log10),

--- a/Source/msfa/controllers.h
+++ b/Source/msfa/controllers.h
@@ -22,10 +22,6 @@
 #include <stdio.h>
 #include <string.h>
 
-#ifdef _WIN32
-#define snprintf _snprintf
-#endif
-
 // State of MIDI controllers
 const uint8_t kControllerPitch = 128;
 const uint8_t kControllerPitchRangeUp = 129;

--- a/Source/msfa/dx7note.cc
+++ b/Source/msfa/dx7note.cc
@@ -201,7 +201,7 @@ void Dx7Note::init(const uint8_t patch[156], int midinote, int velocity, int cha
         levels[i] = patch[130 + i];
     }
     pitchenv_.set(rates, levels);
-    algorithm_ = patch[134];
+    algorithm_ = patch[134] & 0x1f;
     int feedback = patch[135];
     fb_shift_ = feedback != 0 ? FEEDBACK_BITDEPTH - feedback : 16;
     pitchmoddepth_ = (patch[139] * 165) >> 6;
@@ -239,7 +239,9 @@ void Dx7Note::compute(int32_t *buf, int32_t lfo_val, int32_t lfo_delay, const Co
             else
                 pb = ((float) (pb << 11)) * ((float) ctrls->values_[kControllerPitchRangeDn]) / 12.0;
         } else {
-            int stp = 12 / ctrls->values_[kControllerPitchStep];
+            int pitchStep = ctrls->values_[kControllerPitchStep];
+            int stp = (pitchStep > 0 && pitchStep <= 12) ? 12 / pitchStep : 1;
+            if (stp == 0) stp = 1;
             pb = pb * stp / 8191;
             pb = (pb * (8191 / stp)) << 11;
         }
@@ -393,7 +395,7 @@ void Dx7Note::update(const uint8_t patch[156], int midinote, int velocity, int c
         int rate_scaling = ScaleRate(midinote, patch[off + 13]);
         env_[op].update(rates, levels, outlevel, rate_scaling);
     }
-    algorithm_ = patch[134];
+    algorithm_ = patch[134] & 0x1f;
     int feedback = patch[135];
     fb_shift_ = feedback != 0 ? FEEDBACK_BITDEPTH - feedback : 16;
     pitchmoddepth_ = (patch[139] * 165) >> 6;

--- a/Source/msfa/env.cc
+++ b/Source/msfa/env.cc
@@ -46,6 +46,13 @@ const int statics[] = {
 
 Env::Env() {
     initialised_ = false;
+    staticcount_ = 0;
+    level_ = 0;
+    targetlevel_ = 0;
+    rising_ = false;
+    ix_ = 0;
+    inc_ = 0;
+    down_ = true;
 }
 
 void Env::init_sr(double sampleRate) {

--- a/Source/msfa/exp2.h
+++ b/Source/msfa/exp2.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#pragma once
+
 class Exp2 {
  public:
   Exp2();

--- a/Source/msfa/exp2.h
+++ b/Source/msfa/exp2.h
@@ -41,7 +41,10 @@ int32_t Exp2::lookup(int32_t x) {
   int y0 = exp2tab[x_int + 1];
 
   int y = y0 + (((int64_t)dy * (int64_t)lowbits) >> SHIFT);
-  return y >> (6 - (x >> 24));
+  int shift = 6 - (x >> 24);
+  if (shift < 0) return y << (-shift);
+  if (shift > 31) return 0;
+  return y >> shift;
 }
 #endif
 

--- a/Source/msfa/freqlut.cc
+++ b/Source/msfa/freqlut.cc
@@ -51,5 +51,8 @@ int32_t Freqlut::lookup(int32_t logfreq) {
   int lowbits = logfreq & ((1 << SAMPLE_SHIFT) - 1);
   int32_t y = y0 + ((((int64_t)(y1 - y0) * (int64_t)lowbits)) >> SAMPLE_SHIFT);
   int hibits = logfreq >> 24;
-  return y >> (MAX_LOGFREQ_INT - hibits);
+  int shift = MAX_LOGFREQ_INT - hibits;
+  if (shift < 0) return y << (-shift);
+  if (shift > 31) return 0;
+  return y >> shift;
 }

--- a/Source/msfa/freqlut.h
+++ b/Source/msfa/freqlut.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#pragma once
+
 class Freqlut {
  public:
   static void init(double sample_rate);

--- a/Source/msfa/lfo.h
+++ b/Source/msfa/lfo.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#pragma once
+
 // Low frequency oscillator, compatible with DX7
 
 class Lfo {

--- a/Source/msfa/sin.h
+++ b/Source/msfa/sin.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#pragma once
+
 class Sin {
  public:
   Sin();

--- a/Source/msfa/synth.h
+++ b/Source/msfa/synth.h
@@ -17,22 +17,12 @@
 #ifndef __SYNTH_H
 #define __SYNTH_H
 
-// This IS not be present on MSVC.
-// See http://stackoverflow.com/questions/126279/c99-stdint-h-header-and-ms-visual-studio
 #include <stdint.h>
-#ifdef _MSC_VER
-typedef __int32 int32_t;
-typedef unsigned __int32 uint32_t;
-typedef __int16 SInt16;
-#endif
 
 const static int LG_N = 6;
 const static int N = (1 << LG_N);
 
-#if defined(__APPLE__)
-#include <libkern/OSAtomic.h>
-#define SynthMemoryBarrier() OSMemoryBarrier()
-#elif defined(__GNUC__)
+#if defined(__APPLE__) || defined(__GNUC__)
 #if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 1)
 #define SynthMemoryBarrier() __sync_synchronize()
 #endif

--- a/assets/installers/make_macos_pkg.sh
+++ b/assets/installers/make_macos_pkg.sh
@@ -82,7 +82,7 @@ build_flavor()
       [[ -z $MAC_INSTALLING_CERT ]] && echo "You need an installing cert too " && exit 2
       echo "Singning $workdir/$flavorprod"
       codesign --force -s "$MAC_SIGNING_CERT" -o runtime --deep "$workdir/$flavorprod"
-      codesign  -vvv --deep --stric "$workdir/$flavorprod"
+      codesign  -vvv --deep --strict "$workdir/$flavorprod"
 
       pkgbuild --sign "$MAC_INSTALLING_CERT" --root $workdir --identifier $ident --version $VERSION --install-location "$loc" "$TMPDIR/${PRODUCTFILE}_${flavor}.pkg" $sca || exit 1
     else


### PR DESCRIPTION
## Summary

- **Fix 12 safety-critical bugs**: null derefs, out-of-bounds array access, undefined behavior from invalid shift amounts, division by zero, buffer overflows, and data corruption in sysex handling
- **Fix CI/build issues**: script injection in GitHub Actions, codesign typo in macOS installer, wrong CMake flag on Windows CI, remove obsolete MSVC macros, add missing include guards
- **Fix EngineMkI audio quality bug**: gain interpolation in `compute_fb2`/`compute_fb3` was always zero, causing zipper noise on algorithms 4 and 6
- **Add random voice generator (RND button)**: generates musically-biased random DX7 patches with sensible envelope shapes, harmonic frequency ratios, and subtle LFO
- **Add resizable window**: corner drag handle with aspect ratio constraint, scales from 50% to screen-height-fitted maximum
- **Add 4-operator sysex import**: automatically detects and converts DX21/DX27/DX100/TX81Z bulk sysex files to DX7-compatible 6-operator format

## Details

### Safety-Critical Fixes
| Fix | File |
|-----|------|
| Add missing `return` after null file error | `PluginData.cpp` |
| Mask algorithm index to 0-31 | `dx7note.cc` |
| Change sysex offset from `uint8` to `int` | `PluginProcessor.cpp` |
| Guard `PluginFx::process` against zero-length buffers | `PluginFx.cpp` |
| Add `default` case to filter switch | `PluginFx.cpp` |
| Clamp shift amounts in `Exp2::lookup` and `Freqlut::lookup` | `exp2.h`, `freqlut.cc` |
| Null-terminate `opSwitch` after `strncpy` | `PluginData.cpp` |
| Add null check in `setupStartupCart` | `PluginData.cpp` |
| Remove `memcpy` overwriting normalized sysex data | `PluginData.cpp` |
| Clamp `portamento_cc` from XML to 0-127 | `PluginData.cpp` |
| Guard `pitchStep` division against zero | `dx7note.cc` |

### 4-Op Import
Converts 4-op patches by mapping algorithms (1-8 → DX7 equivalents), scaling envelope rates (0-31 → 0-99), converting DX100 frequency ratio indices to DX7 coarse+fine, and silencing unused operators 5-6. Tested with DX100 factory patches.

## Test plan
- [x] Build succeeds on Windows (VS 2022 Build Tools, MSVC 14.44)
- [x] Standalone app launches and plays audio correctly
- [x] RND button generates varied, musical random patches
- [x] Window resizes with corner drag, maintains aspect ratio
- [x] DX100 .syx files load and play through 4-op converter
- [ ] Build on macOS
- [ ] Build on Linux
- [ ] Test as VST3 plugin in a DAW

🤖 Generated with [Claude Code](https://claude.com/claude-code)